### PR TITLE
Fix possible null-access error in "removeFromFrameworksPbxGroup"

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -644,6 +644,9 @@ pbxProject.prototype.addToFrameworksPbxGroup = function(file) {
 }
 
 pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
+    if (!this.pbxGroupByName('Frameworks')) {
+        return null;
+    }
     var pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
 
     for (i in pluginsGroupChildren) {


### PR DESCRIPTION
The method `project.removeFromFrameworksPbxGroup` directly tries to
access `children` on `project.pbxGroupByName` - but this method might
return `null` if no such group exists.
To prevent a runtime error when trying to access a property on `null` we
can add a check whether the requested group "Frameworks" does exist in
the project and only then continue with the removal of the file.