### PR TITLE
CB-12844 Update pbxProject.js

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1546,7 +1546,7 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     obj.inputPaths = options.inputPaths || [];
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
-    obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
+    obj.shellScript = '"' + options.shellScript.replace(/\\/g, '\\\\') + '"';
 
     return obj;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1546,7 +1546,7 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     obj.inputPaths = options.inputPaths || [];
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
-    obj.shellScript = '"' + options.shellScript.replace(/\\/g, '\\\\') + '"';
+    obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"').replace(/\\/g, '\\\\') + '"'; ;
 
     return obj;
 }


### PR DESCRIPTION
Modifying backlashes to reduce escape character incompatibilities. Jira issue : CB-12844
Escape backslashes when creating a PBXShellScriptBuildPhase