### PR TITLE
CB-13592 Fixed bug where comment is not removed on removing embedded frameworks.

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -484,10 +484,11 @@ pbxProject.prototype.removeFromPbxBuildFileSection = function(file) {
         if (this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
+
+            var commentKey = f("%s_comment", uuid);
+            delete this.pbxBuildFileSection()[commentKey];
         }
     }
-    var commentKey = f("%s_comment", file.uuid);
-    delete this.pbxBuildFileSection()[commentKey];
 }
 
 pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTree) {

--- a/test/removeFramework.js
+++ b/test/removeFramework.js
@@ -166,5 +166,32 @@ exports.removeFramework = {
         }
 
         test.done();
+    },
+    'should remove embedded frameworks': function (test) {
+        var newFile = proj.addFramework('/path/to/Custom.framework', { customFramework: true, embed:true, sign:true }),
+            frameworks = proj.pbxFrameworksBuildPhaseObj(),
+            buildFileSection = proj.pbxBuildFileSection(),
+            bfsLength = Object.keys(buildFileSection).length;
+
+        test.equal(frameworks.files.length, 16);
+        test.equal(62, bfsLength);
+
+        var deletedFile = proj.removeFramework('/path/to/Custom.framework', { customFramework: true, embed:true }),
+            frameworks = proj.pbxFrameworksBuildPhaseObj(),
+            buildFileSection = proj.pbxBuildFileSection(),
+            bfsLength = Object.keys(buildFileSection).length;
+
+        test.equal(frameworks.files.length, 15);
+        test.equal(58, bfsLength);
+
+        var frameworkPaths = frameworkSearchPaths(proj);
+        expectedPath = '"/path/to"';
+
+        for (i = 0; i < frameworkPaths.length; i++) {
+            var current = frameworkPaths[i];
+            test.ok(current.indexOf(expectedPath) == -1);
+        }
+
+        test.done();
     }
 }


### PR DESCRIPTION
Currently after adding an embedded framework, 4 entries are added to the PBXBuildFileSection.

```
        "128CD4F705D24987A12F213E": {
          "isa": "PBXBuildFile",
          "fileRef": "021AA25C78F942DA94C24904",
          "fileRef_comment": "EmbedThirdParty.framework"
        },
        "128CD4F705D24987A12F213E_comment": "EmbedThirdParty.framework in Frameworks",
        "B9B17AE7AA7C4663BA933B64": {
          "isa": "PBXBuildFile",
          "fileRef": "021AA25C78F942DA94C24904",
          "fileRef_comment": "EmbedThirdParty.framework",
          "settings": {
            "ATTRIBUTES": ["CodeSignOnCopy"]
          }
        },
        "B9B17AE7AA7C4663BA933B64_comment": "EmbedThirdParty.framework in Embed Frameworks",
```

After calling removeFramework function,  the current existing code will incorrectly leave a orphan entry in the PBXFileSection:

```
        "B9B17AE7AA7C4663BA933B64_comment": "EmbedThirdParty.framework in Embed Frameworks",
```

This pull request fixes this issue, and adds a relevant unit test in removeFramework.js