### PR TITLE
Fixed addTo* methods

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1179,7 +1179,8 @@ pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
             continue;
 
         if (!buildSettings['FRAMEWORK_SEARCH_PATHS']
-            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED
+            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === '""') {
             buildSettings['FRAMEWORK_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -1227,7 +1228,8 @@ pbxProject.prototype.addToLibrarySearchPaths = function(file) {
             continue;
 
         if (!buildSettings['LIBRARY_SEARCH_PATHS']
-            || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED
+            || buildSettings['LIBRARY_SEARCH_PATHS'] === '""') {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -1275,7 +1277,9 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file) {
         if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
             continue;
 
-        if (!buildSettings['HEADER_SEARCH_PATHS']) {
+        if (!buildSettings['HEADER_SEARCH_PATHS']
+            || buildSettings['HEADER_SEARCH_PATHS'] === INHERITED
+            || buildSettings['HEADER_SEARCH_PATHS'] === '""') {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
         }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1283,6 +1283,17 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file) {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
         }
 
+        var isDuplicate = false;
+        buildSettings['HEADER_SEARCH_PATHS'].forEach(function(existingFile){
+            if(file === existingFile) {
+                isDuplicate = true;
+            }
+        });
+
+        if(isDuplicate) {
+            continue;
+        }
+
         if (typeof file === 'string') {
             buildSettings['HEADER_SEARCH_PATHS'].push(file);
         } else {


### PR DESCRIPTION
addToFrameworkSearchPaths and other methods fail in projects where FRAMEWORK_SEARCH_PATHS is initialized as `""` with following error:

```
.../node_modules/xcode/lib/pbxProject.js:1186
TypeError: buildSettings.FRAMEWORK_SEARCH_PATHS.push is not a function
```
  