### PR TITLE
Fix issues with pbxFile extension and addTargetDependency sections

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -21,7 +21,8 @@ var path = require('path'),
 var DEFAULT_SOURCETREE = '"<group>"',
     DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR',
     DEFAULT_FILEENCODING = 4,
-    DEFAULT_GROUP = 'Resources';
+    DEFAULT_GROUP = 'Resources',
+    DEFAULT_FILETYPE = 'unknown';
 
 var FILETYPE_BY_EXTENSION = {
         a: 'archive.ar',
@@ -82,18 +83,23 @@ var FILETYPE_BY_EXTENSION = {
 
 
 function unquoted(text){
-    return text == null ? '' : text.replace (/(^")|("$)/g, '')
+    return text.replace (/(^")|("$)/g, '')
 }
 
 function detectType(filePath) {
     var extension = path.extname(filePath).substring(1),
         filetype = FILETYPE_BY_EXTENSION[unquoted(extension)];
 
+    if (!filetype) {
+        return DEFAULT_FILETYPE;
+    }
+
     return filetype;
 }
 
 function defaultExtension(fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+        fileRef.lastKnownFileType : fileRef.explicitFileType;
 
     for(var extension in FILETYPE_BY_EXTENSION) {
         if(FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension)) ) {
@@ -104,7 +110,8 @@ function defaultExtension(fileRef) {
 }
 
 function defaultEncoding(fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+            fileRef.lastKnownFileType : fileRef.explicitFileType,
         encoding = ENCODING_BY_FILETYPE[unquoted(filetype)];
 
     if (encoding) {
@@ -114,7 +121,8 @@ function defaultEncoding(fileRef) {
 
 function detectGroup(fileRef, opt) {
     var extension = path.extname(fileRef.basename).substring(1),
-        filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+        filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+            fileRef.lastKnownFileType : fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
 
     if (extension === 'xcdatamodeld') {
@@ -134,7 +142,8 @@ function detectGroup(fileRef, opt) {
 
 function detectSourcetree(fileRef) {
 
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+            fileRef.lastKnownFileType : fileRef.explicitFileType,
         sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
 
     if (fileRef.explicitFileType) {
@@ -153,7 +162,8 @@ function detectSourcetree(fileRef) {
 }
 
 function defaultPath(fileRef, filePath) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+            fileRef.lastKnownFileType : fileRef.explicitFileType,
         defaultPath = PATH_BY_FILETYPE[unquoted(filetype)];
 
     if (fileRef.customFramework) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -83,7 +83,7 @@ var FILETYPE_BY_EXTENSION = {
 
 
 function unquoted(text){
-    return text.replace (/(^")|("$)/g, '')
+    return text == null ? '' : text.replace (/(^")|("$)/g, '')
 }
 
 function detectType(filePath) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -21,8 +21,7 @@ var path = require('path'),
 var DEFAULT_SOURCETREE = '"<group>"',
     DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR',
     DEFAULT_FILEENCODING = 4,
-    DEFAULT_GROUP = 'Resources',
-    DEFAULT_FILETYPE = 'unknown';
+    DEFAULT_GROUP = 'Resources';
 
 var FILETYPE_BY_EXTENSION = {
         a: 'archive.ar',
@@ -83,16 +82,12 @@ var FILETYPE_BY_EXTENSION = {
 
 
 function unquoted(text){
-    return text.replace (/(^")|("$)/g, '')
+    return text == null ? '' : text.replace (/(^")|("$)/g, '')
 }
 
 function detectType(filePath) {
     var extension = path.extname(filePath).substring(1),
         filetype = FILETYPE_BY_EXTENSION[unquoted(extension)];
-
-    if (!filetype) {
-        return DEFAULT_FILETYPE;
-    }
 
     return filetype;
 }
@@ -102,7 +97,7 @@ function defaultExtension(fileRef) {
 
     for(var extension in FILETYPE_BY_EXTENSION) {
         if(FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension)) ) {
-             if(FILETYPE_BY_EXTENSION[unquoted(extension)] === filetype )
+             if(FILETYPE_BY_EXTENSION[unquoted(extension)] === unquoted(filetype) )
                  return extension;
         }
     }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1100,24 +1100,32 @@ pbxProject.prototype.buildPhaseObject = function(name, group, target) {
     return null;
 }
 
-pbxProject.prototype.addBuildProperty = function(prop, value, build_name) {
+pbxProject.prototype.addBuildProperty = function(prop, value, build_name, product_name) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         key, configuration;
 
     for (key in configurations){
         configuration = configurations[key];
+
+        if (product_name && unquote(configuration.buildSettings['PRODUCT_NAME']) != product_name)
+            continue;
+
         if (!build_name || configuration.name === build_name){
             configuration.buildSettings[prop] = value;
         }
     }
 }
 
-pbxProject.prototype.removeBuildProperty = function(prop, build_name) {
+pbxProject.prototype.removeBuildProperty = function(prop, build_name, product_name) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         key, configuration;
 
     for (key in configurations){
         configuration = configurations[key];
+
+        if (product_name && unquote(configuration.buildSettings['PRODUCT_NAME']) != product_name)
+            continue;
+
         if (configuration.buildSettings[prop] &&
             !build_name || configuration.name === build_name){
             delete configuration.buildSettings[prop];

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -857,13 +857,19 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
                 targetProxy_comment: pbxContainerItemProxy
             };
 
-        if (pbxContainerItemProxySection && pbxTargetDependencySection) {
-            pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
-            pbxContainerItemProxySection[itemProxyCommentKey] = pbxContainerItemProxy;
-            pbxTargetDependencySection[targetDependencyUuid] = targetDependency;
-            pbxTargetDependencySection[targetDependencyCommentKey] = pbxTargetDependency;
-            nativeTargets[target].dependencies.push({ value: targetDependencyUuid, comment: pbxTargetDependency })
+        if (!pbxTargetDependencySection) {
+            pbxTargetDependencySection = this.hash.project.objects[pbxTargetDependency] = new Object();
         }
+
+        if (!pbxContainerItemProxySection) {
+            pbxContainerItemProxySection = this.hash.project.objects[pbxContainerItemProxy] = new Object();
+        }
+
+        pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
+        pbxContainerItemProxySection[itemProxyCommentKey] = pbxContainerItemProxy;
+        pbxTargetDependencySection[targetDependencyUuid] = targetDependency;
+        pbxTargetDependencySection[targetDependencyCommentKey] = pbxTargetDependency;
+        nativeTargets[target].dependencies.push({ value: targetDependencyUuid, comment: pbxTargetDependency })
     }
 
     return { uuid: target, target: nativeTargets[target] };

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1293,7 +1293,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file, opt) {
         buildSettings = configurations[config].buildSettings;
 
         var productName = opt && opt.productName ? opt.productName : this.productName;
-        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) !== productName)
             continue;
 
         if (!buildSettings['HEADER_SEARCH_PATHS']) {
@@ -1318,7 +1318,7 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag, opt) {
         buildSettings = configurations[config].buildSettings;
 
         var productName = opt && opt.productName ? opt.productName : this.productName;
-        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) !== productName)
             continue;
 
         if (!buildSettings[OTHER_LDFLAGS]
@@ -1339,7 +1339,7 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag, opt) {
         buildSettings = configurations[config].buildSettings;
 
         var productName = opt && opt.productName ? opt.productName : this.productName;
-        if (unquote(buildSettings['PRODUCT_NAME']) != productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== productName) {
             continue;
         }
 
@@ -1615,7 +1615,7 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
-    if(options.showEnvVarsInLog != null && !options.showEnvVarsInLog) {
+    if(options.showEnvVarsInLog !== null && options.showEnvVarsInLog !== undefined  && !options.showEnvVarsInLog) {
         obj.showEnvVarsInLog = 0;
     }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1147,7 +1147,7 @@ pbxProject.prototype.updateProductName = function(name) {
     this.updateBuildProperty('PRODUCT_NAME', '"' + name + '"');
 }
 
-pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
+pbxProject.prototype.removeFromFrameworkSearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS',
@@ -1157,7 +1157,8 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         searchPaths = buildSettings[SEARCH_PATHS];
@@ -1174,7 +1175,7 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
     }
 }
 
-pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
+pbxProject.prototype.addToFrameworkSearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -1182,7 +1183,8 @@ pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         if (!buildSettings['FRAMEWORK_SEARCH_PATHS']
@@ -1194,7 +1196,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
     }
 }
 
-pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
+pbxProject.prototype.removeFromLibrarySearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS',
@@ -1204,7 +1206,8 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         searchPaths = buildSettings[SEARCH_PATHS];
@@ -1222,7 +1225,7 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
     }
 }
 
-pbxProject.prototype.addToLibrarySearchPaths = function(file) {
+pbxProject.prototype.addToLibrarySearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -1230,7 +1233,8 @@ pbxProject.prototype.addToLibrarySearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         if (!buildSettings['LIBRARY_SEARCH_PATHS']
@@ -1246,7 +1250,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function(file) {
     }
 }
 
-pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
+pbxProject.prototype.removeFromHeaderSearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
@@ -1256,7 +1260,8 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         if (buildSettings[SEARCH_PATHS]) {
@@ -1271,7 +1276,7 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
 
     }
 }
-pbxProject.prototype.addToHeaderSearchPaths = function(file) {
+pbxProject.prototype.addToHeaderSearchPaths = function(file, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -1279,7 +1284,8 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         if (!buildSettings['HEADER_SEARCH_PATHS']) {
@@ -1294,7 +1300,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file) {
     }
 }
 
-pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
+pbxProject.prototype.addToOtherLinkerFlags = function (flag, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         OTHER_LDFLAGS = 'OTHER_LDFLAGS',
@@ -1303,7 +1309,8 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName)
             continue;
 
         if (!buildSettings[OTHER_LDFLAGS]
@@ -1315,7 +1322,7 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     }
 }
 
-pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
+pbxProject.prototype.removeFromOtherLinkerFlags = function (flag, opt) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         OTHER_LDFLAGS = 'OTHER_LDFLAGS',
         config, buildSettings;
@@ -1323,7 +1330,8 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        var productName = opt && opt.productName ? opt.productName : this.productName;
+        if (unquote(buildSettings['PRODUCT_NAME']) != productName) {
             continue;
         }
 
@@ -1599,6 +1607,9 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
+    if(options.showEnvVarsInLog != null && !options.showEnvVarsInLog) {
+        obj.showEnvVarsInLog = 0;
+    }
 
     return obj;
 }

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -89,10 +89,10 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
-    'should set lastKnownFileType to null if undetectable': function (test) {
+    'should set lastKnownFileType to unknown if undetectable': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
-        test.equal(null, sourceFile.lastKnownFileType);
+        test.equal('unknown', sourceFile.lastKnownFileType);
         test.done();
     }
 }

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -280,7 +280,7 @@ exports['settings'] = {
         test.done();
     },
 
-    'should have extension if {explicitFileType:"blah"} specified': function (test) {
+    'should be .appex if {explicitFileType:\'"wrapper.app-extension"\'} specified': function (test) {
         var sourceFile = new pbxFile('AppExtension',
             { explicitFileType: '"wrapper.app-extension"'});
 

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -89,10 +89,10 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
-    'should set lastKnownFileType to unknown if undetectable': function (test) {
+    'should set lastKnownFileType to null if undetectable': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
-        test.equal('unknown', sourceFile.lastKnownFileType);
+        test.equal(null, sourceFile.lastKnownFileType);
         test.done();
     }
 }
@@ -277,6 +277,14 @@ exports['settings'] = {
             { compilerFlags: "-std=c++11 -fno-objc-arc" });
 
         test.deepEqual({COMPILER_FLAGS:'"-std=c++11 -fno-objc-arc"'}, sourceFile.settings);
+        test.done();
+    },
+
+    'should have extension if {explicitFileType:"blah"} specified': function (test) {
+        var sourceFile = new pbxFile('AppExtension',
+            { explicitFileType: '"wrapper.app-extension"'});
+
+        test.ok(sourceFile.basename === 'AppExtension.appex');
         test.done();
     }
 }


### PR DESCRIPTION
This PR fixes a few issues I discovered while using this library to add an app extension to a pbxproject.

1. `new pbxFile('AppExtension', { explicitFileType: '"wrapper.app-extension"'})` gets indirectly called when using `proj.addTarget('AppExtension', 'app_extension')`. This results in an incorrect extension being added to the basename when trying to determine the extension from `defaultExtension` (`detectType` sets it to the literal string "unknown" which fails falsey checks). The result would end up being `AppExtension.undefined` instead of the correct `AppExtension.appex`. Also corrected a missing `unquoted()` call in the `defaultExtension()` function which also led to the same failure.

2. `addTargetDependency()` is indirectly called as well from `proj.addTarget('AppExtension', 'app_extension')`. In my project, `PBXTargetDependency` and `PBXContainerItemProxy` sections did not yet exist which results in the necessary dependencies not being set up properly for building the extension with the main app. Create these sections if they do not exist.

3. In the various functions that build out `buildSettings`, it checks for the `PRODUCT_NAME` to be the same as the project's product name. This never matches if you are using these functions on the app extension, since it has a different `PRODUCT_NAME`. Allow a product name to be passed as an option to these functions.

4. Added `showEnvVarsInLog` option to `pbxShellScriptBuildPhaseObj`. Passing this a false will set `showEnvVarsInLog = 0`.

All tests (and the newly added) pass.