### PR TITLE
Updated to use ECMAScript 2015 Object.assign.

### DIFF
--- a/lib/parser/pbxproj.js
+++ b/lib/parser/pbxproj.js
@@ -178,7 +178,7 @@ function peg$parse(input, options) {
               var returnObject = list[0][0];
               for(var i = 1; i < list.length; i++){
                   var another = list[i][0];
-                  returnObject = merge_obj(returnObject, another);
+                  returnObject = Object.assign(returnObject, another);
               }
               return returnObject;
           },
@@ -1878,18 +1878,6 @@ function peg$parse(input, options) {
 
     return s0;
   }
-
-
-      function merge_obj(obj, secondObj) {
-          if (!obj)
-              return secondObj;
-
-          for(var i in secondObj)
-              obj[i] = merge_obj(obj[i], secondObj[i]);
-
-          return obj;
-      }
-
 
   peg$result = peg$startRuleFunction();
 


### PR DESCRIPTION
Updated pbxproj.js to use ECMAScript 2015 Object.assign to avoid Maximum call stack size exceeded error when running react-native link.

I was getting the above error when running link in the Ignite Bowser template. This fix resolved that. Object.assign targets ECMAScript 2015 though so I see how that might be an issue if you want to target previous versions.