### PR TITLE
Introduce .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+sudo: false
+
+git:
+  depth: 10
+
+node_js:
+  - 0.8
+  - 0.10
+  - 0.12
+  - 4
+  - 6
+  - 8
+  - 10
+
+install:
+  - nvm --version
+  - node --version
+  - npm --version
+  # remaining install steps can be removed once we drop Node.js 0.8 support:
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.8" ] ; then nvm install --latest-npm 0.8 ; fi'
+  - npm install
+  - node --version
+  - npm --version
+
+
+script:
+  - npm test


### PR DESCRIPTION
copied from `cordova-common`, with some changes and no coverage included

with an adaptation needed to work on deprecated Node.js 0.8 version

gives me a green build on all supported Node.js versions, back to 0.8, in <https://travis-ci.org/brodybits/cordova-node-xcode/builds/463944951>

Needed to unblock Travis CI testing (#16).

While I would favor dropping old Node.js versions (#17) we should not do this before making a new major release. (Some non-Cordova projects may still need old Node.js support, maybe even back to 0.8.) I would favor introducing Travis CI in the current release in case we need to support it, with old Node.js versions, for any reason.

P.S. INFRA request is in <https://issues.apache.org/jira/browse/INFRA-17368>.