### PR TITLE
Resolve issue with pbxFile extension

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -83,7 +83,7 @@ var FILETYPE_BY_EXTENSION = {
 
 
 function unquoted(text){
-    return text.replace (/(^")|("$)/g, '')
+    return text == null ? '' : text.replace (/(^")|("$)/g, '')
 }
 
 function detectType(filePath) {
@@ -98,11 +98,12 @@ function detectType(filePath) {
 }
 
 function defaultExtension(fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
+        fileRef.lastKnownFileType : fileRef.explicitFileType;
 
     for(var extension in FILETYPE_BY_EXTENSION) {
         if(FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension)) ) {
-             if(FILETYPE_BY_EXTENSION[unquoted(extension)] === filetype )
+             if(FILETYPE_BY_EXTENSION[unquoted(extension)] === unquoted(filetype) )
                  return extension;
         }
     }

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -284,7 +284,7 @@ exports['settings'] = {
         var sourceFile = new pbxFile('AppExtension',
             { explicitFileType: '"wrapper.app-extension"'});
 
-        test.ok(sourceFile.basename === 'AppExtension.appex');
+        test.equal('AppExtension.appex', sourceFile.basename);
         test.done();
     }
 }

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -278,5 +278,13 @@ exports['settings'] = {
 
         test.deepEqual({COMPILER_FLAGS:'"-std=c++11 -fno-objc-arc"'}, sourceFile.settings);
         test.done();
+    },
+
+    'should be .appex if {explicitFileType:\'"wrapper.app-extension"\'} specified': function (test) {
+        var sourceFile = new pbxFile('AppExtension',
+            { explicitFileType: '"wrapper.app-extension"'});
+
+        test.ok(sourceFile.basename === 'AppExtension.appex');
+        test.done();
     }
 }


### PR DESCRIPTION
where `pbxFile` extension was being set to `undefined`

and add new test case to verify the bug fix

NOTE: These changes were originally part of PR #12,
extracted here by @brodybits (Christopher J. Brody).

/cc @n1ru4l @kspearrin