### PR TITLE
[WIP] eslint & prettier enhancements WIP for evaluation & discussion

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+lib/parser

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,6 +19,9 @@ rules:
   # general custom rule(s):
   camelcase: off
 
+  # TBD ignore for now, due to prettier-eslint:
+  standard/computed-property-even-spacing: off
+
   # FUTURE TBD configure these globally or not:
   # no-throw-literal: off
   # no-unused-vars:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,26 @@
+root: true
+
+extends:
+  - standard
+
+rules:
+  # semistandard rules:
+  semi:
+    - error
+    - always
+  no-extra-semi:
+    - error
+
+  # general indent rule:
+  indent:
+    - error
+    - 4
+
+  # general custom rule(s):
+  camelcase: off
+
+  # FUTURE TBD configure these globally or not:
+  # no-throw-literal: off
+  # no-unused-vars:
+  #   - error
+  #   - args: after-used

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,6 +17,8 @@ rules:
     - 4
 
   # general custom rule(s):
+  no-var: error
+  prefer-const: error
   camelcase: off
 
   # TBD ignore for now, due to prettier-eslint:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,3 @@ install:
 
 script:
   - npm test
-  # TODO MOVE eslint into npm test once we drop Node.js pre-6.0
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "6" ] ; then npm run eslint ; fi'
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "8" ] ; then npm run eslint ; fi'
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "10" ] ; then npm run eslint ; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,7 @@ install:
 
 script:
   - npm test
+  # TODO MOVE eslint into npm test once we drop Node.js pre-6.0
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "6" ] ; then npm run eslint ; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "8" ] ; then npm run eslint ; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "10" ] ; then npm run eslint ; fi'

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -13,7 +13,6 @@ rules:
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
   eqeqeq: off
   func-call-spacing: off
-  indent: off
   key-spacing: off
   keyword-spacing: off
   no-extra-semi: off
@@ -28,9 +27,5 @@ rules:
   operator-linebreak: off
   padded-blocks: off
   quotes: off
-  semi: off
-  space-before-blocks: off
-  space-before-function-paren: off
-  space-in-parens: off
   space-infix-ops: off
   standard/object-curly-even-spacing: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,6 +1,5 @@
 rules:
   # Specific to lib:
-  curly: off
   new-cap: off
   no-dupe-keys: off
   no-new-object: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,31 +1,16 @@
 rules:
   # Specific to lib:
-  brace-style: off
-  comma-dangle: off
   curly: off
   new-cap: off
   no-dupe-keys: off
-  no-mixed-operators: off
-  no-multi-spaces: off
   no-new-object: off
   spaced-comment: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
   eqeqeq: off
-  func-call-spacing: off
-  key-spacing: off
-  keyword-spacing: off
-  no-extra-semi: off
-  no-multiple-empty-lines: off
   no-path-concat: off
   no-redeclare: off
   no-undef: off
   no-unneeded-ternary: off
   no-unused-vars: off
-  object-curly-spacing: off
   one-var: off
-  operator-linebreak: off
-  padded-blocks: off
-  quotes: off
-  space-infix-ops: off
-  standard/object-curly-even-spacing: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,7 +1,6 @@
 rules:
   # Specific to lib:
   new-cap: off
-  no-new-object: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
   no-path-concat: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -3,7 +3,6 @@ rules:
   new-cap: off
   no-dupe-keys: off
   no-new-object: off
-  spaced-comment: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
   eqeqeq: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -3,7 +3,6 @@ rules:
   new-cap: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
-  no-path-concat: off
   no-redeclare: off
   no-undef: off
   no-unneeded-ternary: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,0 +1,36 @@
+rules:
+  # Specific to lib:
+  brace-style: off
+  comma-dangle: off
+  curly: off
+  new-cap: off
+  no-dupe-keys: off
+  no-mixed-operators: off
+  no-multi-spaces: off
+  no-new-object: off
+  spaced-comment: off
+
+  # TODO: Resolve the issues in the code so that these rules can be re-enabled:
+  eqeqeq: off
+  func-call-spacing: off
+  indent: off
+  key-spacing: off
+  keyword-spacing: off
+  no-extra-semi: off
+  no-multiple-empty-lines: off
+  no-path-concat: off
+  no-redeclare: off
+  no-undef: off
+  no-unneeded-ternary: off
+  no-unused-vars: off
+  object-curly-spacing: off
+  one-var: off
+  operator-linebreak: off
+  padded-blocks: off
+  quotes: off
+  semi: off
+  space-before-blocks: off
+  space-before-function-paren: off
+  space-in-parens: off
+  space-infix-ops: off
+  standard/object-curly-even-spacing: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -5,7 +5,6 @@ rules:
   no-new-object: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:
-  eqeqeq: off
   no-path-concat: off
   no-redeclare: off
   no-undef: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -7,4 +7,3 @@ rules:
   no-undef: off
   no-unneeded-ternary: off
   no-unused-vars: off
-  one-var: off

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,7 +1,6 @@
 rules:
   # Specific to lib:
   new-cap: off
-  no-dupe-keys: off
   no-new-object: off
 
   # TODO: Resolve the issues in the code so that these rules can be re-enabled:

--- a/lib/parseJob.js
+++ b/lib/parseJob.js
@@ -20,7 +20,8 @@
 var fs = require('fs'),
     parser = require('./parser/pbxproj'),
     path = process.argv[2],
-    fileContents, obj;
+    fileContents,
+    obj;
 
 try {
     fileContents = fs.readFileSync(path, 'utf-8');

--- a/lib/parseJob.js
+++ b/lib/parseJob.js
@@ -17,11 +17,11 @@
 
 // parsing is slow and blocking right now
 // so we do it in a separate process
-var fs = require('fs'),
-    parser = require('./parser/pbxproj'),
-    path = process.argv[2],
-    fileContents,
-    obj;
+const fs = require('fs');
+const parser = require('./parser/pbxproj');
+const path = process.argv[2];
+let fileContents;
+let obj;
 
 try {
     fileContents = fs.readFileSync(path, 'utf-8');

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -15,78 +15,78 @@
  under the License.
  */
 
-var path = require('path'),
-    util = require('util');
+const path = require('path');
+const util = require('util');
 
-var DEFAULT_SOURCETREE = '"<group>"',
-    DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR',
-    DEFAULT_FILEENCODING = 4,
-    DEFAULT_GROUP = 'Resources',
-    DEFAULT_FILETYPE = 'unknown';
+const DEFAULT_SOURCETREE = '"<group>"';
+const DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR';
+const DEFAULT_FILEENCODING = 4;
+const DEFAULT_GROUP = 'Resources';
+const DEFAULT_FILETYPE = 'unknown';
 
-var FILETYPE_BY_EXTENSION = {
-        a: 'archive.ar',
-        app: 'wrapper.application',
-        appex: 'wrapper.app-extension',
-        bundle: 'wrapper.plug-in',
-        dylib: 'compiled.mach-o.dylib',
-        framework: 'wrapper.framework',
-        h: 'sourcecode.c.h',
-        m: 'sourcecode.c.objc',
-        markdown: 'text',
-        mdimporter: 'wrapper.cfbundle',
-        octest: 'wrapper.cfbundle',
-        pch: 'sourcecode.c.h',
-        plist: 'text.plist.xml',
-        sh: 'text.script.sh',
-        swift: 'sourcecode.swift',
-        tbd: 'sourcecode.text-based-dylib-definition',
-        xcassets: 'folder.assetcatalog',
-        xcconfig: 'text.xcconfig',
-        xcdatamodel: 'wrapper.xcdatamodel',
-        xcodeproj: 'wrapper.pb-project',
-        xctest: 'wrapper.cfbundle',
-        xib: 'file.xib',
-        strings: 'text.plist.strings'
-    },
-    GROUP_BY_FILETYPE = {
-        'archive.ar': 'Frameworks',
-        'compiled.mach-o.dylib': 'Frameworks',
-        'sourcecode.text-based-dylib-definition': 'Frameworks',
-        'wrapper.framework': 'Frameworks',
-        'embedded.framework': 'Embed Frameworks',
-        'sourcecode.c.h': 'Resources',
-        'sourcecode.c.objc': 'Sources',
-        'sourcecode.swift': 'Sources'
-    },
-    PATH_BY_FILETYPE = {
-        'compiled.mach-o.dylib': 'usr/lib/',
-        'sourcecode.text-based-dylib-definition': 'usr/lib/',
-        'wrapper.framework': 'System/Library/Frameworks/'
-    },
-    SOURCETREE_BY_FILETYPE = {
-        'compiled.mach-o.dylib': 'SDKROOT',
-        'sourcecode.text-based-dylib-definition': 'SDKROOT',
-        'wrapper.framework': 'SDKROOT'
-    },
-    ENCODING_BY_FILETYPE = {
-        'sourcecode.c.h': 4,
-        'sourcecode.c.objc': 4,
-        'sourcecode.swift': 4,
-        text: 4, // -- [prettier] object key with no quotes
-        'text.plist.xml': 4,
-        'text.script.sh': 4,
-        'text.xcconfig': 4,
-        'text.plist.strings': 4
-    };
+const FILETYPE_BY_EXTENSION = {
+    a: 'archive.ar',
+    app: 'wrapper.application',
+    appex: 'wrapper.app-extension',
+    bundle: 'wrapper.plug-in',
+    dylib: 'compiled.mach-o.dylib',
+    framework: 'wrapper.framework',
+    h: 'sourcecode.c.h',
+    m: 'sourcecode.c.objc',
+    markdown: 'text',
+    mdimporter: 'wrapper.cfbundle',
+    octest: 'wrapper.cfbundle',
+    pch: 'sourcecode.c.h',
+    plist: 'text.plist.xml',
+    sh: 'text.script.sh',
+    swift: 'sourcecode.swift',
+    tbd: 'sourcecode.text-based-dylib-definition',
+    xcassets: 'folder.assetcatalog',
+    xcconfig: 'text.xcconfig',
+    xcdatamodel: 'wrapper.xcdatamodel',
+    xcodeproj: 'wrapper.pb-project',
+    xctest: 'wrapper.cfbundle',
+    xib: 'file.xib',
+    strings: 'text.plist.strings'
+};
+const GROUP_BY_FILETYPE = {
+    'archive.ar': 'Frameworks',
+    'compiled.mach-o.dylib': 'Frameworks',
+    'sourcecode.text-based-dylib-definition': 'Frameworks',
+    'wrapper.framework': 'Frameworks',
+    'embedded.framework': 'Embed Frameworks',
+    'sourcecode.c.h': 'Resources',
+    'sourcecode.c.objc': 'Sources',
+    'sourcecode.swift': 'Sources'
+};
+const PATH_BY_FILETYPE = {
+    'compiled.mach-o.dylib': 'usr/lib/',
+    'sourcecode.text-based-dylib-definition': 'usr/lib/',
+    'wrapper.framework': 'System/Library/Frameworks/'
+};
+const SOURCETREE_BY_FILETYPE = {
+    'compiled.mach-o.dylib': 'SDKROOT',
+    'sourcecode.text-based-dylib-definition': 'SDKROOT',
+    'wrapper.framework': 'SDKROOT'
+};
+const ENCODING_BY_FILETYPE = {
+    'sourcecode.c.h': 4,
+    'sourcecode.c.objc': 4,
+    'sourcecode.swift': 4,
+    text: 4, // -- [prettier] object key with no quotes
+    'text.plist.xml': 4,
+    'text.script.sh': 4,
+    'text.xcconfig': 4,
+    'text.plist.strings': 4
+};
 
 function unquoted (text) {
     return text === null ? '' : text.replace(/(^")|("$)/g, '');
 }
 
 function detectType (filePath) {
-    var extension = path.extname(filePath).substring(1),
-        filetype = FILETYPE_BY_EXTENSION[unquoted(extension)];
+    const extension = path.extname(filePath).substring(1);
+    const filetype = FILETYPE_BY_EXTENSION[unquoted(extension)];
 
     if (!filetype) {
         return DEFAULT_FILETYPE;
@@ -96,13 +96,13 @@ function detectType (filePath) {
 }
 
 function defaultExtension (fileRef) {
-    var filetype =
+    const filetype =
         fileRef.lastKnownFileType &&
         fileRef.lastKnownFileType !== DEFAULT_FILETYPE
             ? fileRef.lastKnownFileType
             : fileRef.explicitFileType;
 
-    for (var extension in FILETYPE_BY_EXTENSION) {
+    for (const extension in FILETYPE_BY_EXTENSION) {
         if (FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension))) {
             if (
                 FILETYPE_BY_EXTENSION[unquoted(extension)] ===
@@ -115,8 +115,8 @@ function defaultExtension (fileRef) {
 }
 
 function defaultEncoding (fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
-        encoding = ENCODING_BY_FILETYPE[unquoted(filetype)];
+    const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    const encoding = ENCODING_BY_FILETYPE[unquoted(filetype)];
 
     if (encoding) {
         return encoding;
@@ -124,9 +124,9 @@ function defaultEncoding (fileRef) {
 }
 
 function detectGroup (fileRef, opt) {
-    var extension = path.extname(fileRef.basename).substring(1),
-        filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
-        groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
+    const extension = path.extname(fileRef.basename).substring(1);
+    const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    const groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
 
     if (extension === 'xcdatamodeld') {
         return 'Sources';
@@ -144,8 +144,8 @@ function detectGroup (fileRef, opt) {
 }
 
 function detectSourcetree (fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
-        sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
+    const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    const sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
 
     if (fileRef.explicitFileType) {
         return DEFAULT_PRODUCT_SOURCETREE;
@@ -163,8 +163,8 @@ function detectSourcetree (fileRef) {
 }
 
 function defaultPath (fileRef, filePath) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
-        defaultPath = PATH_BY_FILETYPE[unquoted(filetype)];
+    const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+    const defaultPath = PATH_BY_FILETYPE[unquoted(filetype)];
 
     if (fileRef.customFramework) {
         return filePath;
@@ -178,7 +178,7 @@ function defaultPath (fileRef, filePath) {
 }
 
 function defaultGroup (fileRef) {
-    var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
+    const groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
 
     if (!groupName) {
         return DEFAULT_GROUP;
@@ -187,8 +187,8 @@ function defaultGroup (fileRef) {
     return defaultGroup;
 }
 
-function pbxFile (filepath, opt) {
-    var opt = opt || {};
+function pbxFile (filepath, opts) {
+    const opt = opts || {};
 
     this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -81,12 +81,11 @@ var FILETYPE_BY_EXTENSION = {
         'text.plist.strings': 4
     };
 
-
-function unquoted(text){
-    return text == null ? '' : text.replace (/(^")|("$)/g, '')
+function unquoted (text) {
+    return text == null ? '' : text.replace(/(^")|("$)/g, '');
 }
 
-function detectType(filePath) {
+function detectType (filePath) {
     var extension = path.extname(filePath).substring(1),
         filetype = FILETYPE_BY_EXTENSION[unquoted(extension)];
 
@@ -97,19 +96,25 @@ function detectType(filePath) {
     return filetype;
 }
 
-function defaultExtension(fileRef) {
-    var filetype = fileRef.lastKnownFileType && fileRef.lastKnownFileType != DEFAULT_FILETYPE ?
-        fileRef.lastKnownFileType : fileRef.explicitFileType;
+function defaultExtension (fileRef) {
+    var filetype =
+        fileRef.lastKnownFileType &&
+        fileRef.lastKnownFileType != DEFAULT_FILETYPE
+            ? fileRef.lastKnownFileType
+            : fileRef.explicitFileType;
 
-    for(var extension in FILETYPE_BY_EXTENSION) {
-        if(FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension)) ) {
-             if(FILETYPE_BY_EXTENSION[unquoted(extension)] === unquoted(filetype) )
-                 return extension;
+    for (var extension in FILETYPE_BY_EXTENSION) {
+        if (FILETYPE_BY_EXTENSION.hasOwnProperty(unquoted(extension))) {
+            if (
+                FILETYPE_BY_EXTENSION[unquoted(extension)] ===
+                unquoted(filetype)
+            )
+                return extension;
         }
     }
 }
 
-function defaultEncoding(fileRef) {
+function defaultEncoding (fileRef) {
     var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         encoding = ENCODING_BY_FILETYPE[unquoted(filetype)];
 
@@ -118,7 +123,7 @@ function defaultEncoding(fileRef) {
     }
 }
 
-function detectGroup(fileRef, opt) {
+function detectGroup (fileRef, opt) {
     var extension = path.extname(fileRef.basename).substring(1),
         filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
@@ -138,8 +143,7 @@ function detectGroup(fileRef, opt) {
     return groupName;
 }
 
-function detectSourcetree(fileRef) {
-
+function detectSourcetree (fileRef) {
     var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
 
@@ -158,7 +162,7 @@ function detectSourcetree(fileRef) {
     return sourcetree;
 }
 
-function defaultPath(fileRef, filePath) {
+function defaultPath (fileRef, filePath) {
     var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         defaultPath = PATH_BY_FILETYPE[unquoted(filetype)];
 
@@ -173,7 +177,7 @@ function defaultPath(fileRef, filePath) {
     return filePath;
 }
 
-function defaultGroup(fileRef) {
+function defaultGroup (fileRef) {
     var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
 
     if (!groupName) {
@@ -183,7 +187,7 @@ function defaultGroup(fileRef) {
     return defaultGroup;
 }
 
-function pbxFile(filepath, opt) {
+function pbxFile (filepath, opt) {
     var opt = opt || {};
 
     this.basename = path.basename(filepath);
@@ -197,7 +201,8 @@ function pbxFile(filepath, opt) {
     }
 
     this.path = defaultPath(this, filepath).replace(/\\/g, '/');
-    this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(this);
+    this.fileEncoding = this.defaultEncoding =
+        opt.defaultEncoding || defaultEncoding(this);
 
     // When referencing products / build output files
     if (opt.explicitFileType) {
@@ -216,17 +221,14 @@ function pbxFile(filepath, opt) {
         this.settings = { ATTRIBUTES: ['Weak'] };
 
     if (opt.compilerFlags) {
-        if (!this.settings)
-            this.settings = {};
+        if (!this.settings) this.settings = {};
         this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
     }
 
     if (opt.embed && opt.sign) {
-      if (!this.settings)
-          this.settings = {};
-      if (!this.settings.ATTRIBUTES)
-          this.settings.ATTRIBUTES = [];
-      this.settings.ATTRIBUTES.push('CodeSignOnCopy');
+        if (!this.settings) this.settings = {};
+        if (!this.settings.ATTRIBUTES) this.settings.ATTRIBUTES = [];
+        this.settings.ATTRIBUTES.push('CodeSignOnCopy');
     }
 }
 

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -108,8 +108,9 @@ function defaultExtension (fileRef) {
             if (
                 FILETYPE_BY_EXTENSION[unquoted(extension)] ===
                 unquoted(filetype)
-            )
+            ) {
                 return extension;
+            }
         }
     }
 }
@@ -217,8 +218,9 @@ function pbxFile (filepath, opt) {
     this.sourceTree = opt.sourceTree || detectSourcetree(this);
     this.includeInIndex = 0;
 
-    if (opt.weak && opt.weak === true)
+    if (opt.weak && opt.weak === true) {
         this.settings = { ATTRIBUTES: ['Weak'] };
+    }
 
     if (opt.compilerFlags) {
         if (!this.settings) this.settings = {};

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -82,7 +82,7 @@ var FILETYPE_BY_EXTENSION = {
     };
 
 function unquoted (text) {
-    return text == null ? '' : text.replace(/(^")|("$)/g, '');
+    return text === null ? '' : text.replace(/(^")|("$)/g, '');
 }
 
 function detectType (filePath) {
@@ -99,7 +99,7 @@ function detectType (filePath) {
 function defaultExtension (fileRef) {
     var filetype =
         fileRef.lastKnownFileType &&
-        fileRef.lastKnownFileType != DEFAULT_FILETYPE
+        fileRef.lastKnownFileType !== DEFAULT_FILETYPE
             ? fileRef.lastKnownFileType
             : fileRef.explicitFileType;
 
@@ -196,7 +196,7 @@ function pbxFile (filepath, opt) {
     this.group = detectGroup(this, opt);
 
     // for custom frameworks
-    if (opt.customFramework == true) {
+    if (opt.customFramework === true) {
         this.customFramework = true;
         this.dirname = path.dirname(filepath).replace(/\\/g, '/');
     }

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -74,7 +74,7 @@ var FILETYPE_BY_EXTENSION = {
         'sourcecode.c.h': 4,
         'sourcecode.c.objc': 4,
         'sourcecode.swift': 4,
-        'text': 4,
+        text: 4, // -- [prettier] object key with no quotes
         'text.plist.xml': 4,
         'text.script.sh': 4,
         'text.xcconfig': 4,

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -71,7 +71,6 @@ var FILETYPE_BY_EXTENSION = {
     },
     ENCODING_BY_FILETYPE = {
         'sourcecode.c.h': 4,
-        'sourcecode.c.h': 4,
         'sourcecode.c.objc': 4,
         'sourcecode.swift': 4,
         text: 4, // -- [prettier] object key with no quotes

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -26,28 +26,30 @@ var util = require('util'),
     fs = require('fs'),
     parser = require('./parser/pbxproj'),
     plist = require('simple-plist'),
-    COMMENT_KEY = /_comment$/
+    COMMENT_KEY = /_comment$/;
 
-function pbxProject(filename) {
-    if (!(this instanceof pbxProject))
-        return new pbxProject(filename);
+function pbxProject (filename) {
+    if (!(this instanceof pbxProject)) return new pbxProject(filename);
 
-    this.filepath = path.resolve(filename)
+    this.filepath = path.resolve(filename);
 }
 
-util.inherits(pbxProject, EventEmitter)
+util.inherits(pbxProject, EventEmitter);
 
-pbxProject.prototype.parse = function(cb) {
-    var worker = fork(__dirname + '/parseJob.js', [this.filepath])
+pbxProject.prototype.parse = function (cb) {
+    var worker = fork(__dirname + '/parseJob.js', [this.filepath]);
 
-    worker.on('message', function(msg) {
-        if (msg.name == 'SyntaxError' || msg.code) {
-            this.emit('error', msg);
-        } else {
-            this.hash = msg;
-            this.emit('end', null, msg)
-        }
-    }.bind(this));
+    worker.on(
+        'message',
+        function (msg) {
+            if (msg.name == 'SyntaxError' || msg.code) {
+                this.emit('error', msg);
+            } else {
+                this.hash = msg;
+                this.emit('end', null, msg);
+            }
+        }.bind(this)
+    );
 
     if (cb) {
         this.on('error', cb);
@@ -55,51 +57,52 @@ pbxProject.prototype.parse = function(cb) {
     }
 
     return this;
-}
+};
 
-pbxProject.prototype.parseSync = function() {
+pbxProject.prototype.parseSync = function () {
     var file_contents = fs.readFileSync(this.filepath, 'utf-8');
 
     this.hash = parser.parse(file_contents);
     return this;
-}
+};
 
-pbxProject.prototype.writeSync = function(options) {
+pbxProject.prototype.writeSync = function (options) {
     this.writer = new pbxWriter(this.hash, options);
     return this.writer.writeSync();
-}
+};
 
-pbxProject.prototype.allUuids = function() {
+pbxProject.prototype.allUuids = function () {
     var sections = this.hash.project.objects,
         uuids = [],
         section;
 
     for (key in sections) {
-        section = sections[key]
-        uuids = uuids.concat(Object.keys(section))
+        section = sections[key];
+        uuids = uuids.concat(Object.keys(section));
     }
 
-    uuids = uuids.filter(function(str) {
+    uuids = uuids.filter(function (str) {
         return !COMMENT_KEY.test(str) && str.length == 24;
     });
 
     return uuids;
-}
+};
 
-pbxProject.prototype.generateUuid = function() {
-    var id = uuid.v4()
+pbxProject.prototype.generateUuid = function () {
+    var id = uuid
+        .v4()
         .replace(/-/g, '')
         .substr(0, 24)
-        .toUpperCase()
+        .toUpperCase();
 
     if (this.allUuids().indexOf(id) >= 0) {
         return this.generateUuid();
     } else {
         return id;
     }
-}
+};
 
-pbxProject.prototype.addPluginFile = function(path, opt) {
+pbxProject.prototype.addPluginFile = function (path, opt) {
     var file = new pbxFile(path, opt);
 
     file.plugin = true; // durr
@@ -114,9 +117,9 @@ pbxProject.prototype.addPluginFile = function(path, opt) {
     this.addToPluginsPbxGroup(file); //         -- PBXGroup
 
     return file;
-}
+};
 
-pbxProject.prototype.removePluginFile = function(path, opt) {
+pbxProject.prototype.removePluginFile = function (path, opt) {
     var file = new pbxFile(path, opt);
     correctForPluginsPath(file, this);
 
@@ -124,9 +127,9 @@ pbxProject.prototype.removePluginFile = function(path, opt) {
     this.removeFromPluginsPbxGroup(file); //         -- PBXGroup
 
     return file;
-}
+};
 
-pbxProject.prototype.addProductFile = function(targetPath, opt) {
+pbxProject.prototype.addProductFile = function (targetPath, opt) {
     var file = new pbxFile(targetPath, opt);
 
     file.includeInIndex = 0;
@@ -140,15 +143,15 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
     this.addToProductsPbxGroup(file); //        -- PBXGroup
 
     return file;
-}
+};
 
-pbxProject.prototype.removeProductFile = function(path, opt) {
+pbxProject.prototype.removeProductFile = function (path, opt) {
     var file = new pbxFile(path, opt);
 
     this.removeFromProductsPbxGroup(file); // -- PBXGroup
 
     return file;
-}
+};
 
 /**
  *
@@ -161,8 +164,7 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
     var file;
     if (group) {
         file = this.addFile(path, group, opt);
-    }
-    else {
+    } else {
         file = this.addPluginFile(path, opt);
     }
 
@@ -175,7 +177,7 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
     this.addToPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
 
     return file;
-}
+};
 
 /**
  *
@@ -188,8 +190,7 @@ pbxProject.prototype.removeSourceFile = function (path, opt, group) {
     var file;
     if (group) {
         file = this.removeFile(path, group, opt);
-    }
-    else {
+    } else {
         file = this.removePluginFile(path, opt);
     }
     file.target = opt ? opt.target : undefined;
@@ -197,7 +198,7 @@ pbxProject.prototype.removeSourceFile = function (path, opt, group) {
     this.removeFromPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
 
     return file;
-}
+};
 
 /**
  *
@@ -209,11 +210,10 @@ pbxProject.prototype.removeSourceFile = function (path, opt, group) {
 pbxProject.prototype.addHeaderFile = function (path, opt, group) {
     if (group) {
         return this.addFile(path, group, opt);
-    }
-    else {
+    } else {
         return this.addPluginFile(path, opt);
     }
-}
+};
 
 /**
  *
@@ -225,11 +225,10 @@ pbxProject.prototype.addHeaderFile = function (path, opt, group) {
 pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
     if (group) {
         return this.removeFile(path, group, opt);
-    }
-    else {
+    } else {
         return this.removePluginFile(path, opt);
     }
-}
+};
 
 /**
  *
@@ -238,7 +237,7 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
  * @param group {String} group key
  * @returns {Object} file; see pbxFile
  */
-pbxProject.prototype.addResourceFile = function(path, opt, group) {
+pbxProject.prototype.addResourceFile = function (path, opt, group) {
     opt = opt || {};
 
     var file;
@@ -269,19 +268,16 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         if (group) {
             if (this.getPBXGroupByKey(group)) {
                 this.addToPbxGroup(file, group); // -- Group other than Resources (i.e. 'splash')
-            }
-            else if (this.getPBXVariantGroupByKey(group)) {
+            } else if (this.getPBXVariantGroupByKey(group)) {
                 this.addToPbxVariantGroup(file, group); // -- PBXVariantGroup
             }
-        }
-        else {
+        } else {
             this.addToResourcesPbxGroup(file); //   -- PBXGroup
         }
-
     }
 
     return file;
-}
+};
 
 /**
  *
@@ -290,7 +286,7 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
  * @param group {String} group key
  * @returns {Object} file; see pbxFile
  */
-pbxProject.prototype.removeResourceFile = function(path, opt, group) {
+pbxProject.prototype.removeResourceFile = function (path, opt, group) {
     var file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -301,26 +297,24 @@ pbxProject.prototype.removeResourceFile = function(path, opt, group) {
     if (group) {
         if (this.getPBXGroupByKey(group)) {
             this.removeFromPbxGroup(file, group); // -- Group other than Resources (i.e. 'splash')
-        }
-        else if (this.getPBXVariantGroupByKey(group)) {
+        } else if (this.getPBXVariantGroupByKey(group)) {
             this.removeFromPbxVariantGroup(file, group); // -- PBXVariantGroup
         }
-    }
-    else {
+    } else {
         this.removeFromResourcesPbxGroup(file); //   -- PBXGroup
     }
     this.removeFromPbxResourcesBuildPhase(file); //  -- PBXResourcesBuildPhase
 
     return file;
-}
+};
 
-pbxProject.prototype.addFramework = function(fpath, opt) {
+pbxProject.prototype.addFramework = function (fpath, opt) {
     var customFramework = opt && opt.customFramework == true;
     var link = !opt || (opt.link == undefined || opt.link); // -- defaults to true if not specified
     var embed = opt && opt.embed; //                           -- defaults to false if not specified
 
     if (opt) {
-      delete opt.embed;
+        delete opt.embed;
     }
 
     var file = new pbxFile(fpath, opt);
@@ -336,36 +330,36 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     this.addToFrameworksPbxGroup(file); //        -- PBXGroup
 
     if (link) {
-      this.addToPbxFrameworksBuildPhase(file); // -- PBXFrameworksBuildPhase
+        this.addToPbxFrameworksBuildPhase(file); // -- PBXFrameworksBuildPhase
     }
 
     if (customFramework) {
         this.addToFrameworkSearchPaths(file);
 
         if (embed) {
-          opt.embed = embed;
-          var embeddedFile = new pbxFile(fpath, opt);
+            opt.embed = embed;
+            var embeddedFile = new pbxFile(fpath, opt);
 
-          embeddedFile.uuid = this.generateUuid();
-          embeddedFile.fileRef = file.fileRef;
+            embeddedFile.uuid = this.generateUuid();
+            embeddedFile.fileRef = file.fileRef;
 
-          // keeping a separate PBXBuildFile entry for Embed Frameworks
-          this.addToPbxBuildFileSection(embeddedFile); //          -- PBXBuildFile
+            // keeping a separate PBXBuildFile entry for Embed Frameworks
+            this.addToPbxBuildFileSection(embeddedFile); //          -- PBXBuildFile
 
-          this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // -- PBXCopyFilesBuildPhase
+            this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // -- PBXCopyFilesBuildPhase
 
-          return embeddedFile;
+            return embeddedFile;
         }
     }
 
     return file;
-}
+};
 
-pbxProject.prototype.removeFramework = function(fpath, opt) {
+pbxProject.prototype.removeFramework = function (fpath, opt) {
     var embed = opt && opt.embed;
 
     if (opt) {
-      delete opt.embed;
+        delete opt.embed;
     }
 
     var file = new pbxFile(fpath, opt);
@@ -386,14 +380,13 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
 
     embeddedFile.fileRef = file.fileRef;
 
-    this.removeFromPbxBuildFileSection(embeddedFile);          // -- PBXBuildFile
+    this.removeFromPbxBuildFileSection(embeddedFile); // -- PBXBuildFile
     this.removeFromPbxEmbedFrameworksBuildPhase(embeddedFile); // -- PBXCopyFilesBuildPhase
 
     return file;
-}
+};
 
-
-pbxProject.prototype.addCopyfile = function(fpath, opt) {
+pbxProject.prototype.addCopyfile = function (fpath, opt) {
     var file = new pbxFile(fpath, opt);
 
     // catch duplicates
@@ -409,18 +402,26 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
     this.addToPbxCopyfilesBuildPhase(file); //  -- PBXCopyFilesBuildPhase
 
     return file;
-}
+};
 
-pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', target);
-}
+pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function (target) {
+    return this.buildPhaseObject(
+        'PBXCopyFilesBuildPhase',
+        'Copy Files',
+        target
+    );
+};
 
-pbxProject.prototype.addToPbxCopyfilesBuildPhase = function(file) {
-    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', file.target);
+pbxProject.prototype.addToPbxCopyfilesBuildPhase = function (file) {
+    var sources = this.buildPhaseObject(
+        'PBXCopyFilesBuildPhase',
+        'Copy Files',
+        file.target
+    );
     sources.files.push(pbxBuildPhaseObj(file));
-}
+};
 
-pbxProject.prototype.removeCopyfile = function(fpath, opt) {
+pbxProject.prototype.removeCopyfile = function (fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -429,9 +430,9 @@ pbxProject.prototype.removeCopyfile = function(fpath, opt) {
     this.removeFromPbxCopyfilesBuildPhase(file); //  -- PBXFrameworksBuildPhase
 
     return file;
-}
+};
 
-pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function(file) {
+pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
     var sources = this.pbxCopyfilesBuildPhaseObj(file.target);
     for (i in sources.files) {
         if (sources.files[i].comment == longComment(file)) {
@@ -439,9 +440,9 @@ pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function(file) {
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addStaticLibrary = function(path, opt) {
+pbxProject.prototype.addStaticLibrary = function (path, opt) {
     opt = opt || {};
 
     var file;
@@ -467,34 +468,41 @@ pbxProject.prototype.addStaticLibrary = function(path, opt) {
     this.addToLibrarySearchPaths(file); //      -- make sure it gets built!
 
     return file;
-}
+};
 
 // helper addition functions
-pbxProject.prototype.addToPbxBuildFileSection = function(file) {
-    var commentKey = f("%s_comment", file.uuid);
+pbxProject.prototype.addToPbxBuildFileSection = function (file) {
+    var commentKey = f('%s_comment', file.uuid);
 
     this.pbxBuildFileSection()[file.uuid] = pbxBuildFileObj(file);
     this.pbxBuildFileSection()[commentKey] = pbxBuildFileComment(file);
-}
+};
 
-pbxProject.prototype.removeFromPbxBuildFileSection = function(file) {
+pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
     var uuid;
 
     for (uuid in this.pbxBuildFileSection()) {
-        if (this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
+        if (
+            this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename
+        ) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
 
-            var commentKey = f("%s_comment", uuid);
+            var commentKey = f('%s_comment', uuid);
             delete this.pbxBuildFileSection()[commentKey];
         }
     }
-}
+};
 
-pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTree) {
+pbxProject.prototype.addPbxGroup = function (
+    filePathsArray,
+    name,
+    path,
+    sourceTree
+) {
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = this.generateUuid(),
-        commentKey = f("%s_comment", pbxGroupUuid),
+        commentKey = f('%s_comment', pbxGroupUuid),
         pbxGroup = {
             isa: 'PBXGroup',
             children: [],
@@ -512,17 +520,24 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
         var fileReferenceKey = key.split(COMMENT_KEY)[0],
             fileReference = fileReferenceSection[fileReferenceKey];
 
-        filePathToReference[fileReference.path] = { fileRef: fileReferenceKey, basename: fileReferenceSection[key] };
+        filePathToReference[fileReference.path] = {
+            fileRef: fileReferenceKey,
+            basename: fileReferenceSection[key]
+        };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
         var filePath = filePathsArray[index],
-            filePathQuoted = "\"" + filePath + "\"";
+            filePathQuoted = '"' + filePath + '"';
         if (filePathToReference[filePath]) {
-            pbxGroup.children.push(pbxGroupChild(filePathToReference[filePath]));
+            pbxGroup.children.push(
+                pbxGroupChild(filePathToReference[filePath])
+            );
             continue;
         } else if (filePathToReference[filePathQuoted]) {
-            pbxGroup.children.push(pbxGroupChild(filePathToReference[filePathQuoted]));
+            pbxGroup.children.push(
+                pbxGroupChild(filePathToReference[filePathQuoted])
+            );
             continue;
         }
 
@@ -540,11 +555,12 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
     }
 
     return { uuid: pbxGroupUuid, pbxGroup: pbxGroup };
-}
+};
 
 pbxProject.prototype.removePbxGroup = function (groupName) {
     var section = this.hash.project.objects['PBXGroup'],
-        key, itemKey;
+        key,
+        itemKey;
 
     for (key in section) {
         // only look for comments
@@ -555,65 +571,74 @@ pbxProject.prototype.removePbxGroup = function (groupName) {
             delete section[itemKey];
         }
     }
-}
+};
 
-pbxProject.prototype.addToPbxProjectSection = function(target) {
-
+pbxProject.prototype.addToPbxProjectSection = function (target) {
     var newTarget = {
-            value: target.uuid,
-            comment: pbxNativeTargetComment(target.pbxNativeTarget)
-        };
+        value: target.uuid,
+        comment: pbxNativeTargetComment(target.pbxNativeTarget)
+    };
 
-    this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(newTarget);
-}
+    this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(
+        newTarget
+    );
+};
 
-pbxProject.prototype.addToPbxNativeTargetSection = function(target) {
-    var commentKey = f("%s_comment", target.uuid);
+pbxProject.prototype.addToPbxNativeTargetSection = function (target) {
+    var commentKey = f('%s_comment', target.uuid);
 
     this.pbxNativeTargetSection()[target.uuid] = target.pbxNativeTarget;
     this.pbxNativeTargetSection()[commentKey] = target.pbxNativeTarget.name;
-}
+};
 
-pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
-    var commentKey = f("%s_comment", file.fileRef);
+pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
+    var commentKey = f('%s_comment', file.fileRef);
 
     this.pbxFileReferenceSection()[file.fileRef] = pbxFileReferenceObj(file);
-    this.pbxFileReferenceSection()[commentKey] = pbxFileReferenceComment(file);
-}
+    this.pbxFileReferenceSection()[commentKey] = pbxFileReferenceComment(
+        file
+    );
+};
 
-pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
-
+pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
     var i;
     var refObj = pbxFileReferenceObj(file);
     for (i in this.pbxFileReferenceSection()) {
-        if (this.pbxFileReferenceSection()[i].name == refObj.name ||
-            ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
+        if (
+            this.pbxFileReferenceSection()[i].name == refObj.name ||
+            '"' + this.pbxFileReferenceSection()[i].name + '"' ==
+                refObj.name ||
             this.pbxFileReferenceSection()[i].path == refObj.path ||
-            ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
+            '"' + this.pbxFileReferenceSection()[i].path + '"' == refObj.path
+        ) {
             file.fileRef = file.uuid = i;
             delete this.pbxFileReferenceSection()[i];
             break;
         }
     }
-    var commentKey = f("%s_comment", file.fileRef);
+    var commentKey = f('%s_comment', file.fileRef);
     if (this.pbxFileReferenceSection()[commentKey] != undefined) {
         delete this.pbxFileReferenceSection()[commentKey];
     }
 
     return file;
-}
+};
 
-pbxProject.prototype.addToXcVersionGroupSection = function(file) {
+pbxProject.prototype.addToXcVersionGroupSection = function (file) {
     if (!file.models || !file.currentModel) {
-        throw new Error("Cannot create a XCVersionGroup section from not a data model document file");
+        throw new Error(
+            'Cannot create a XCVersionGroup section from not a data model document file'
+        );
     }
 
-    var commentKey = f("%s_comment", file.fileRef);
+    var commentKey = f('%s_comment', file.fileRef);
 
     if (!this.xcVersionGroupSection()[file.fileRef]) {
         this.xcVersionGroupSection()[file.fileRef] = {
             isa: 'XCVersionGroup',
-            children: file.models.map(function (el) { return el.fileRef; }),
+            children: file.models.map(function (el) {
+                return el.fileRef;
+            }),
             currentVersion: file.currentModel.fileRef,
             name: path.basename(file.path),
             path: file.path,
@@ -622,84 +647,92 @@ pbxProject.prototype.addToXcVersionGroupSection = function(file) {
         };
         this.xcVersionGroupSection()[commentKey] = path.basename(file.path);
     }
-}
+};
 
-pbxProject.prototype.addToPluginsPbxGroup = function(file) {
+pbxProject.prototype.addToPluginsPbxGroup = function (file) {
     var pluginsGroup = this.pbxGroupByName('Plugins');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Plugins');
     } else {
         pluginsGroup.children.push(pbxGroupChild(file));
     }
-}
+};
 
-pbxProject.prototype.removeFromPluginsPbxGroup = function(file) {
+pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
     if (!this.pbxGroupByName('Plugins')) {
         return null;
     }
-    var pluginsGroupChildren = this.pbxGroupByName('Plugins').children, i;
+    var pluginsGroupChildren = this.pbxGroupByName('Plugins').children,
+        i;
     for (i in pluginsGroupChildren) {
-        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+        if (
+            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+        ) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addToResourcesPbxGroup = function(file) {
+pbxProject.prototype.addToResourcesPbxGroup = function (file) {
     var pluginsGroup = this.pbxGroupByName('Resources');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Resources');
     } else {
         pluginsGroup.children.push(pbxGroupChild(file));
     }
-}
+};
 
-pbxProject.prototype.removeFromResourcesPbxGroup = function(file) {
+pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
     if (!this.pbxGroupByName('Resources')) {
         return null;
     }
-    var pluginsGroupChildren = this.pbxGroupByName('Resources').children, i;
+    var pluginsGroupChildren = this.pbxGroupByName('Resources').children,
+        i;
     for (i in pluginsGroupChildren) {
-        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+        if (
+            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+        ) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addToFrameworksPbxGroup = function(file) {
+pbxProject.prototype.addToFrameworksPbxGroup = function (file) {
     var pluginsGroup = this.pbxGroupByName('Frameworks');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Frameworks');
     } else {
         pluginsGroup.children.push(pbxGroupChild(file));
     }
-}
+};
 
-pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
+pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
     if (!this.pbxGroupByName('Frameworks')) {
         return null;
     }
     var pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
 
     for (i in pluginsGroupChildren) {
-        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+        if (
+            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+        ) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
-}
+};
 
 pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
     var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
     if (sources) {
         sources.files.push(pbxBuildPhaseObj(file));
     }
-}
+};
 
 pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
     var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
@@ -712,54 +745,58 @@ pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
         }
         sources.files = files;
     }
-}
+};
 
-pbxProject.prototype.addToProductsPbxGroup = function(file) {
+pbxProject.prototype.addToProductsPbxGroup = function (file) {
     var productsGroup = this.pbxGroupByName('Products');
     if (!productsGroup) {
         this.addPbxGroup([file.path], 'Products');
     } else {
         productsGroup.children.push(pbxGroupChild(file));
     }
-}
+};
 
-pbxProject.prototype.removeFromProductsPbxGroup = function(file) {
+pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
     if (!this.pbxGroupByName('Products')) {
         return null;
     }
-    var productsGroupChildren = this.pbxGroupByName('Products').children, i;
+    var productsGroupChildren = this.pbxGroupByName('Products').children,
+        i;
     for (i in productsGroupChildren) {
-        if (pbxGroupChild(file).value == productsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == productsGroupChildren[i].comment) {
+        if (
+            pbxGroupChild(file).value == productsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == productsGroupChildren[i].comment
+        ) {
             productsGroupChildren.splice(i, 1);
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addToPbxSourcesBuildPhase = function(file) {
+pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
     var sources = this.pbxSourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
-}
+};
 
-pbxProject.prototype.removeFromPbxSourcesBuildPhase = function(file) {
-
-    var sources = this.pbxSourcesBuildPhaseObj(file.target), i;
+pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
+    var sources = this.pbxSourcesBuildPhaseObj(file.target),
+        i;
     for (i in sources.files) {
         if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addToPbxResourcesBuildPhase = function(file) {
+pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
     var sources = this.pbxResourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
-}
+};
 
-pbxProject.prototype.removeFromPbxResourcesBuildPhase = function(file) {
-    var sources = this.pbxResourcesBuildPhaseObj(file.target), i;
+pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
+    var sources = this.pbxResourcesBuildPhaseObj(file.target),
+        i;
 
     for (i in sources.files) {
         if (sources.files[i].comment == longComment(file)) {
@@ -767,14 +804,14 @@ pbxProject.prototype.removeFromPbxResourcesBuildPhase = function(file) {
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addToPbxFrameworksBuildPhase = function(file) {
+pbxProject.prototype.addToPbxFrameworksBuildPhase = function (file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
-}
+};
 
-pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function(file) {
+pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
     for (i in sources.files) {
         if (sources.files[i].comment == longComment(file)) {
@@ -782,13 +819,17 @@ pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function(file) {
             break;
         }
     }
-}
+};
 
-pbxProject.prototype.addXCConfigurationList = function(configurationObjectsArray, defaultConfigurationName, comment) {
+pbxProject.prototype.addXCConfigurationList = function (
+    configurationObjectsArray,
+    defaultConfigurationName,
+    comment
+) {
     var pbxBuildConfigurationSection = this.pbxXCBuildConfigurationSection(),
         pbxXCConfigurationListSection = this.pbxXCConfigurationList(),
         xcConfigurationListUuid = this.generateUuid(),
-        commentKey = f("%s_comment", xcConfigurationListUuid),
+        commentKey = f('%s_comment', xcConfigurationListUuid),
         xcConfigurationList = {
             isa: 'XCConfigurationList',
             buildConfigurations: [],
@@ -799,52 +840,75 @@ pbxProject.prototype.addXCConfigurationList = function(configurationObjectsArray
     for (var index = 0; index < configurationObjectsArray.length; index++) {
         var configuration = configurationObjectsArray[index],
             configurationUuid = this.generateUuid(),
-            configurationCommentKey = f("%s_comment", configurationUuid);
+            configurationCommentKey = f('%s_comment', configurationUuid);
 
         pbxBuildConfigurationSection[configurationUuid] = configuration;
-        pbxBuildConfigurationSection[configurationCommentKey] = configuration.name;
-        xcConfigurationList.buildConfigurations.push({ value: configurationUuid, comment: configuration.name });
+        pbxBuildConfigurationSection[configurationCommentKey] =
+            configuration.name;
+        xcConfigurationList.buildConfigurations.push({
+            value: configurationUuid,
+            comment: configuration.name
+        });
     }
 
     if (pbxXCConfigurationListSection) {
-        pbxXCConfigurationListSection[xcConfigurationListUuid] = xcConfigurationList;
+        pbxXCConfigurationListSection[
+            xcConfigurationListUuid
+        ] = xcConfigurationList;
         pbxXCConfigurationListSection[commentKey] = comment;
     }
 
-    return { uuid: xcConfigurationListUuid, xcConfigurationList: xcConfigurationList };
-}
+    return {
+        uuid: xcConfigurationListUuid,
+        xcConfigurationList: xcConfigurationList
+    };
+};
 
-pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
-    if (!target)
-        return undefined;
+pbxProject.prototype.addTargetDependency = function (
+    target,
+    dependencyTargets
+) {
+    if (!target) return undefined;
 
     var nativeTargets = this.pbxNativeTargetSection();
 
-    if (typeof nativeTargets[target] == "undefined")
-        throw new Error("Invalid target: " + target);
+    if (typeof nativeTargets[target] == 'undefined')
+        throw new Error('Invalid target: ' + target);
 
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTarget = dependencyTargets[index];
-        if (typeof nativeTargets[dependencyTarget] == "undefined")
-            throw new Error("Invalid target: " + dependencyTarget);
-        }
+        if (typeof nativeTargets[dependencyTarget] == 'undefined')
+            throw new Error('Invalid target: ' + dependencyTarget);
+    }
 
     var pbxTargetDependency = 'PBXTargetDependency',
         pbxContainerItemProxy = 'PBXContainerItemProxy',
-        pbxTargetDependencySection = this.hash.project.objects[pbxTargetDependency],
-        pbxContainerItemProxySection = this.hash.project.objects[pbxContainerItemProxy];
+        pbxTargetDependencySection = this.hash.project.objects[
+            pbxTargetDependency
+        ],
+        pbxContainerItemProxySection = this.hash.project.objects[
+            pbxContainerItemProxy
+        ];
 
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTargetUuid = dependencyTargets[index],
-            dependencyTargetCommentKey = f("%s_comment", dependencyTargetUuid),
+            dependencyTargetCommentKey = f(
+                '%s_comment',
+                dependencyTargetUuid
+            ),
             targetDependencyUuid = this.generateUuid(),
-            targetDependencyCommentKey = f("%s_comment", targetDependencyUuid),
+            targetDependencyCommentKey = f(
+                '%s_comment',
+                targetDependencyUuid
+            ),
             itemProxyUuid = this.generateUuid(),
-            itemProxyCommentKey = f("%s_comment", itemProxyUuid),
+            itemProxyCommentKey = f('%s_comment', itemProxyUuid),
             itemProxy = {
                 isa: pbxContainerItemProxy,
                 containerPortal: this.hash.project['rootObject'],
-                containerPortal_comment: this.hash.project['rootObject_comment'],
+                containerPortal_comment: this.hash.project[
+                    'rootObject_comment'
+                ],
                 proxyType: 1,
                 remoteGlobalIDString: dependencyTargetUuid,
                 remoteInfo: nativeTargets[dependencyTargetUuid].name
@@ -859,23 +923,39 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
 
         if (pbxContainerItemProxySection && pbxTargetDependencySection) {
             pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
-            pbxContainerItemProxySection[itemProxyCommentKey] = pbxContainerItemProxy;
-            pbxTargetDependencySection[targetDependencyUuid] = targetDependency;
-            pbxTargetDependencySection[targetDependencyCommentKey] = pbxTargetDependency;
-            nativeTargets[target].dependencies.push({ value: targetDependencyUuid, comment: pbxTargetDependency })
+            pbxContainerItemProxySection[
+                itemProxyCommentKey
+            ] = pbxContainerItemProxy;
+            pbxTargetDependencySection[
+                targetDependencyUuid
+            ] = targetDependency;
+            pbxTargetDependencySection[
+                targetDependencyCommentKey
+            ] = pbxTargetDependency;
+            nativeTargets[target].dependencies.push({
+                value: targetDependencyUuid,
+                comment: pbxTargetDependency
+            });
         }
     }
 
     return { uuid: target, target: nativeTargets[target] };
-}
+};
 
-pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, optionsOrFolderType, subfolderPath) {
+pbxProject.prototype.addBuildPhase = function (
+    filePathsArray,
+    buildPhaseType,
+    comment,
+    target,
+    optionsOrFolderType,
+    subfolderPath
+) {
     var buildPhaseSection,
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
         buildPhaseUuid = this.generateUuid(),
         buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
-        commentKey = f("%s_comment", buildPhaseUuid),
+        commentKey = f('%s_comment', buildPhaseUuid),
         buildPhase = {
             isa: buildPhaseType,
             buildActionMask: 2147483647,
@@ -885,9 +965,18 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
         filePathToBuildFile = {};
 
     if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
-        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, optionsOrFolderType, subfolderPath, comment);
+        buildPhase = pbxCopyFilesBuildPhaseObj(
+            buildPhase,
+            optionsOrFolderType,
+            subfolderPath,
+            comment
+        );
     } else if (buildPhaseType === 'PBXShellScriptBuildPhase') {
-        buildPhase = pbxShellScriptBuildPhaseObj(buildPhase, optionsOrFolderType, comment)
+        buildPhase = pbxShellScriptBuildPhaseObj(
+            buildPhase,
+            optionsOrFolderType,
+            comment
+        );
     }
 
     if (!this.hash.project.objects[buildPhaseType]) {
@@ -895,18 +984,24 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
     }
 
     if (!this.hash.project.objects[buildPhaseType][buildPhaseUuid]) {
-        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
+        this.hash.project.objects[buildPhaseType][
+            buildPhaseUuid
+        ] = buildPhase;
         this.hash.project.objects[buildPhaseType][commentKey] = comment;
     }
 
-    if (this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases']) {
-        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
+    if (
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid][
+            'buildPhases'
+        ]
+    ) {
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid][
+            'buildPhases'
+        ].push({
             value: buildPhaseUuid,
             comment: comment
-        })
-
+        });
     }
-
 
     for (var key in buildFileSection) {
         // only look for comments
@@ -920,19 +1015,27 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
 
         var pbxFileObj = new pbxFile(fileReference.path);
 
-        filePathToBuildFile[fileReference.path] = { uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group };
+        filePathToBuildFile[fileReference.path] = {
+            uuid: buildFileKey,
+            basename: pbxFileObj.basename,
+            group: pbxFileObj.group
+        };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
         var filePath = filePathsArray[index],
-            filePathQuoted = "\"" + filePath + "\"",
+            filePathQuoted = '"' + filePath + '"',
             file = new pbxFile(filePath);
 
         if (filePathToBuildFile[filePath]) {
-            buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePath]));
+            buildPhase.files.push(
+                pbxBuildPhaseObj(filePathToBuildFile[filePath])
+            );
             continue;
         } else if (filePathToBuildFile[filePathQuoted]) {
-            buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePathQuoted]));
+            buildPhase.files.push(
+                pbxBuildPhaseObj(filePathToBuildFile[filePathQuoted])
+            );
             continue;
         }
 
@@ -949,27 +1052,27 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
     }
 
     return { uuid: buildPhaseUuid, buildPhase: buildPhase };
-}
+};
 
 // helper access functions
-pbxProject.prototype.pbxProjectSection = function() {
+pbxProject.prototype.pbxProjectSection = function () {
     return this.hash.project.objects['PBXProject'];
-}
-pbxProject.prototype.pbxBuildFileSection = function() {
+};
+pbxProject.prototype.pbxBuildFileSection = function () {
     return this.hash.project.objects['PBXBuildFile'];
-}
+};
 
-pbxProject.prototype.pbxXCBuildConfigurationSection = function() {
+pbxProject.prototype.pbxXCBuildConfigurationSection = function () {
     return this.hash.project.objects['XCBuildConfiguration'];
-}
+};
 
-pbxProject.prototype.pbxFileReferenceSection = function() {
+pbxProject.prototype.pbxFileReferenceSection = function () {
     return this.hash.project.objects['PBXFileReference'];
-}
+};
 
-pbxProject.prototype.pbxNativeTargetSection = function() {
+pbxProject.prototype.pbxNativeTargetSection = function () {
     return this.hash.project.objects['PBXNativeTarget'];
-}
+};
 
 pbxProject.prototype.xcVersionGroupSection = function () {
     if (typeof this.hash.project.objects['XCVersionGroup'] !== 'object') {
@@ -977,15 +1080,16 @@ pbxProject.prototype.xcVersionGroupSection = function () {
     }
 
     return this.hash.project.objects['XCVersionGroup'];
-}
+};
 
-pbxProject.prototype.pbxXCConfigurationList = function() {
+pbxProject.prototype.pbxXCConfigurationList = function () {
     return this.hash.project.objects['XCConfigurationList'];
-}
+};
 
-pbxProject.prototype.pbxGroupByName = function(name) {
+pbxProject.prototype.pbxGroupByName = function (name) {
     var groups = this.hash.project.objects['PBXGroup'],
-        key, groupKey;
+        key,
+        groupKey;
 
     for (key in groups) {
         // only look for comments
@@ -998,13 +1102,13 @@ pbxProject.prototype.pbxGroupByName = function(name) {
     }
 
     return null;
-}
+};
 
-pbxProject.prototype.pbxTargetByName = function(name) {
+pbxProject.prototype.pbxTargetByName = function (name) {
     return this.pbxItemByComment(name, 'PBXNativeTarget');
-}
+};
 
-pbxProject.prototype.findTargetKey = function(name) {
+pbxProject.prototype.findTargetKey = function (name) {
     var targets = this.hash.project.objects['PBXNativeTarget'];
 
     for (var key in targets) {
@@ -1018,11 +1122,12 @@ pbxProject.prototype.findTargetKey = function(name) {
     }
 
     return null;
-}
+};
 
-pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
+pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
     var section = this.hash.project.objects[pbxSectionName],
-        key, itemKey;
+        key,
+        itemKey;
 
     for (key in section) {
         // only look for comments
@@ -1035,89 +1140,101 @@ pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
     }
 
     return null;
-}
+};
 
-pbxProject.prototype.pbxSourcesBuildPhaseObj = function(target) {
+pbxProject.prototype.pbxSourcesBuildPhaseObj = function (target) {
     return this.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', target);
-}
+};
 
-pbxProject.prototype.pbxResourcesBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', target);
-}
+pbxProject.prototype.pbxResourcesBuildPhaseObj = function (target) {
+    return this.buildPhaseObject(
+        'PBXResourcesBuildPhase',
+        'Resources',
+        target
+    );
+};
 
-pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
-}
+pbxProject.prototype.pbxFrameworksBuildPhaseObj = function (target) {
+    return this.buildPhaseObject(
+        'PBXFrameworksBuildPhase',
+        'Frameworks',
+        target
+    );
+};
 
 pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+    return this.buildPhaseObject(
+        'PBXCopyFilesBuildPhase',
+        'Embed Frameworks',
+        target
+    );
 };
 
 // Find Build Phase from group/target
-pbxProject.prototype.buildPhase = function(group, target) {
-
-    if (!target)
-        return undefined;
+pbxProject.prototype.buildPhase = function (group, target) {
+    if (!target) return undefined;
 
     var nativeTargets = this.pbxNativeTargetSection();
-     if (typeof nativeTargets[target] == "undefined")
-        throw new Error("Invalid target: " + target);
+    if (typeof nativeTargets[target] == 'undefined')
+        throw new Error('Invalid target: ' + target);
 
     var nativeTarget = nativeTargets[target];
     var buildPhases = nativeTarget.buildPhases;
-     for(var i in buildPhases)
-     {
+    for (var i in buildPhases) {
         var buildPhase = buildPhases[i];
-        if (buildPhase.comment==group)
-            return buildPhase.value + "_comment";
-        }
+        if (buildPhase.comment == group) return buildPhase.value + '_comment';
     }
+};
 
-pbxProject.prototype.buildPhaseObject = function(name, group, target) {
+pbxProject.prototype.buildPhaseObject = function (name, group, target) {
     var section = this.hash.project.objects[name],
-        obj, sectionKey, key;
+        obj,
+        sectionKey,
+        key;
     var buildPhase = this.buildPhase(group, target);
 
     for (key in section) {
-
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         // select the proper buildPhase
-        if (buildPhase && buildPhase!=key)
-            continue;
+        if (buildPhase && buildPhase != key) continue;
         if (section[key] == group) {
             sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
     }
     return null;
-}
+};
 
-pbxProject.prototype.addBuildProperty = function(prop, value, build_name) {
+pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        key, configuration;
+        key,
+        configuration;
 
-    for (key in configurations){
+    for (key in configurations) {
         configuration = configurations[key];
-        if (!build_name || configuration.name === build_name){
+        if (!build_name || configuration.name === build_name) {
             configuration.buildSettings[prop] = value;
         }
     }
-}
+};
 
-pbxProject.prototype.removeBuildProperty = function(prop, build_name) {
+pbxProject.prototype.removeBuildProperty = function (prop, build_name) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        key, configuration;
+        key,
+        configuration;
 
-    for (key in configurations){
+    for (key in configurations) {
         configuration = configurations[key];
-        if (configuration.buildSettings[prop] &&
-            !build_name || configuration.name === build_name){
+        if (
+            (configuration.buildSettings[prop] && !build_name) ||
+            configuration.name === build_name
+        ) {
             delete configuration.buildSettings[prop];
         }
     }
-}
+};
 
 /**
  *
@@ -1125,27 +1242,29 @@ pbxProject.prototype.removeBuildProperty = function(prop, build_name) {
  * @param value {String|Array|Object|Number|Boolean}
  * @param build {String} Release or Debug
  */
-pbxProject.prototype.updateBuildProperty = function(prop, value, build) {
+pbxProject.prototype.updateBuildProperty = function (prop, value, build) {
     var configs = this.pbxXCBuildConfigurationSection();
     for (var configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
             var config = configs[configName];
-            if ( (build && config.name === build) || (!build) ) {
+            if ((build && config.name === build) || !build) {
                 config.buildSettings[prop] = value;
             }
         }
     }
-}
+};
 
-pbxProject.prototype.updateProductName = function(name) {
+pbxProject.prototype.updateProductName = function (name) {
     this.updateBuildProperty('PRODUCT_NAME', '"' + name + '"');
-}
+};
 
-pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
+pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
     var new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
@@ -1157,21 +1276,23 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
-            var matches = searchPaths.filter(function(p) {
+            var matches = searchPaths.filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
-            matches.forEach(function(m) {
+            matches.forEach(function (m) {
                 var idx = searchPaths.indexOf(m);
                 searchPaths.splice(idx, 1);
             });
         }
     }
-}
+};
 
-pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
+pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1179,20 +1300,26 @@ pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
         if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
             continue;
 
-        if (!buildSettings['FRAMEWORK_SEARCH_PATHS']
-            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
+        if (
+            !buildSettings['FRAMEWORK_SEARCH_PATHS'] ||
+            buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED
+        ) {
             buildSettings['FRAMEWORK_SEARCH_PATHS'] = [INHERITED];
         }
 
-        buildSettings['FRAMEWORK_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        buildSettings['FRAMEWORK_SEARCH_PATHS'].push(
+            searchPathForFile(file, this)
+        );
     }
-}
+};
 
-pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
+pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
     var new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
@@ -1204,22 +1331,23 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
-            var matches = searchPaths.filter(function(p) {
+            var matches = searchPaths.filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
-            matches.forEach(function(m) {
+            matches.forEach(function (m) {
                 var idx = searchPaths.indexOf(m);
                 searchPaths.splice(idx, 1);
             });
         }
-
     }
-}
+};
 
-pbxProject.prototype.addToLibrarySearchPaths = function(file) {
+pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1227,24 +1355,30 @@ pbxProject.prototype.addToLibrarySearchPaths = function(file) {
         if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
             continue;
 
-        if (!buildSettings['LIBRARY_SEARCH_PATHS']
-            || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
+        if (
+            !buildSettings['LIBRARY_SEARCH_PATHS'] ||
+            buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED
+        ) {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
         if (typeof file === 'string') {
             buildSettings['LIBRARY_SEARCH_PATHS'].push(file);
         } else {
-            buildSettings['LIBRARY_SEARCH_PATHS'].push(searchPathForFile(file, this));
+            buildSettings['LIBRARY_SEARCH_PATHS'].push(
+                searchPathForFile(file, this)
+            );
         }
     }
-}
+};
 
-pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
+pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
     var new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
@@ -1254,21 +1388,22 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
             continue;
 
         if (buildSettings[SEARCH_PATHS]) {
-            var matches = buildSettings[SEARCH_PATHS].filter(function(p) {
+            var matches = buildSettings[SEARCH_PATHS].filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
-            matches.forEach(function(m) {
+            matches.forEach(function (m) {
                 var idx = buildSettings[SEARCH_PATHS].indexOf(m);
                 buildSettings[SEARCH_PATHS].splice(idx, 1);
             });
         }
-
     }
-}
-pbxProject.prototype.addToHeaderSearchPaths = function(file) {
+};
+pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
-        config, buildSettings, searchPaths;
+        config,
+        buildSettings,
+        searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1283,16 +1418,19 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file) {
         if (typeof file === 'string') {
             buildSettings['HEADER_SEARCH_PATHS'].push(file);
         } else {
-            buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
+            buildSettings['HEADER_SEARCH_PATHS'].push(
+                searchPathForFile(file, this)
+            );
         }
     }
-}
+};
 
 pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         OTHER_LDFLAGS = 'OTHER_LDFLAGS',
-        config, buildSettings;
+        config,
+        buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1300,19 +1438,22 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
         if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
             continue;
 
-        if (!buildSettings[OTHER_LDFLAGS]
-                || buildSettings[OTHER_LDFLAGS] === INHERITED) {
+        if (
+            !buildSettings[OTHER_LDFLAGS] ||
+            buildSettings[OTHER_LDFLAGS] === INHERITED
+        ) {
             buildSettings[OTHER_LDFLAGS] = [INHERITED];
         }
 
         buildSettings[OTHER_LDFLAGS].push(flag);
     }
-}
+};
 
 pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         OTHER_LDFLAGS = 'OTHER_LDFLAGS',
-        config, buildSettings;
+        config,
+        buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1331,22 +1472,24 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
             });
         }
     }
-}
+};
 
 pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config, buildSettings;
+        config,
+        buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
         buildSettings[buildSetting] = value;
     }
-}
+};
 
 pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config, buildSettings;
+        config,
+        buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1355,12 +1498,13 @@ pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
             delete buildSettings[buildSetting];
         }
     }
-}
+};
 
 // a JS getter. hmmm
-pbxProject.prototype.__defineGetter__("productName", function() {
+pbxProject.prototype.__defineGetter__('productName', function () {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config, productName;
+        config,
+        productName;
 
     for (config in configurations) {
         productName = configurations[config].buildSettings['PRODUCT_NAME'];
@@ -1372,21 +1516,21 @@ pbxProject.prototype.__defineGetter__("productName", function() {
 });
 
 // check if file is present
-pbxProject.prototype.hasFile = function(filePath) {
+pbxProject.prototype.hasFile = function (filePath) {
     var files = nonComments(this.pbxFileReferenceSection()),
-        file, id;
+        file,
+        id;
     for (id in files) {
         file = files[id];
-        if (file.path == filePath || file.path == ('"' + filePath + '"')) {
+        if (file.path == filePath || file.path == '"' + filePath + '"') {
             return file;
         }
     }
 
     return false;
-}
+};
 
-pbxProject.prototype.addTarget = function(name, type, subfolder) {
-
+pbxProject.prototype.addTarget = function (name, type, subfolder) {
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
@@ -1395,17 +1539,17 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
 
     // Check type against list of allowed target types
     if (!targetName) {
-        throw new Error("Target name missing.");
+        throw new Error('Target name missing.');
     }
 
     // Check type against list of allowed target types
     if (!targetType) {
-        throw new Error("Target type missing.");
+        throw new Error('Target type missing.');
     }
 
     // Check type against list of allowed target types
     if (!producttypeForTargettype(targetType)) {
-        throw new Error("Target type invalid: " + targetType);
+        throw new Error('Target type invalid: ' + targetType);
     }
 
     // Build Configuration: Create
@@ -1415,8 +1559,14 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
             isa: 'XCBuildConfiguration',
             buildSettings: {
                 GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
-                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                INFOPLIST_FILE:
+                    '"' +
+                    path.join(
+                        targetSubfolder,
+                        targetSubfolder + '-Info.plist' + '"'
+                    ),
+                LD_RUNPATH_SEARCH_PATHS:
+                    '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
@@ -1425,8 +1575,14 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
             name: 'Release',
             isa: 'XCBuildConfiguration',
             buildSettings: {
-                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
-                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                INFOPLIST_FILE:
+                    '"' +
+                    path.join(
+                        targetSubfolder,
+                        targetSubfolder + '-Info.plist' + '"'
+                    ),
+                LD_RUNPATH_SEARCH_PATHS:
+                    '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
@@ -1434,50 +1590,61 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
     ];
 
     // Build Configuration: Add
-    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"');
+    var buildConfigurations = this.addXCConfigurationList(
+        buildConfigurationsList,
+        'Release',
+        'Build configuration list for PBXNativeTarget "' + targetName + '"'
+    );
 
     // Product: Create
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
         productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, { group: 'Copy Files', 'target': targetUuid, 'explicitFileType': productFileType}),
+        productFile = this.addProductFile(productName, {
+            group: 'Copy Files',
+            target: targetUuid,
+            explicitFileType: productFileType
+        }),
         productFileName = productFile.basename;
-
 
     // Product: Add to build file list
     this.addToPbxBuildFileSection(productFile);
 
     // Target: Create
     var target = {
-            uuid: targetUuid,
-            pbxNativeTarget: {
-                isa: 'PBXNativeTarget',
-                name: '"' + targetName + '"',
-                productName: '"' + targetName + '"',
-                productReference: productFile.fileRef,
-                productType: '"' + producttypeForTargettype(targetType) + '"',
-                buildConfigurationList: buildConfigurations.uuid,
-                buildPhases: [],
-                buildRules: [],
-                dependencies: []
-            }
+        uuid: targetUuid,
+        pbxNativeTarget: {
+            isa: 'PBXNativeTarget',
+            name: '"' + targetName + '"',
+            productName: '"' + targetName + '"',
+            productReference: productFile.fileRef,
+            productType: '"' + producttypeForTargettype(targetType) + '"',
+            buildConfigurationList: buildConfigurations.uuid,
+            buildPhases: [],
+            buildRules: [],
+            dependencies: []
+        }
     };
 
     // Target: Add to PBXNativeTarget section
-    this.addToPbxNativeTargetSection(target)
+    this.addToPbxNativeTargetSection(target);
 
     // Product: Embed (only for "extension"-type targets)
     if (targetType === 'app_extension') {
-
         // Create CopyFiles phase in first target
-        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Copy Files', this.getFirstTarget().uuid,  targetType)
+        this.addBuildPhase(
+            [],
+            'PBXCopyFilesBuildPhase',
+            'Copy Files',
+            this.getFirstTarget().uuid,
+            targetType
+        );
 
         // Add product to CopyFiles phase
-        this.addToPbxCopyfilesBuildPhase(productFile)
+        this.addToPbxCopyfilesBuildPhase(productFile);
 
-       // this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
-
-    };
+        // this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+    }
 
     // Target: Add uuid to root project
     this.addToPbxProjectSection(target);
@@ -1485,14 +1652,12 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
     // Target: Add dependency for this target to first (main) target
     this.addTargetDependency(this.getFirstTarget().uuid, [target.uuid]);
 
-
     // Return target on success
     return target;
-
 };
 
 // helper recursive prop search+replace
-function propReplace(obj, prop, value) {
+function propReplace (obj, prop, value) {
     var o = {};
     for (var p in obj) {
         if (o.hasOwnProperty.call(obj, p)) {
@@ -1506,7 +1671,7 @@ function propReplace(obj, prop, value) {
 }
 
 // helper object creation functions
-function pbxBuildFileObj(file) {
+function pbxBuildFileObj (file) {
     var obj = Object.create(null);
 
     obj.isa = 'PBXBuildFile';
@@ -1517,11 +1682,11 @@ function pbxBuildFileObj(file) {
     return obj;
 }
 
-function pbxFileReferenceObj(file) {
+function pbxFileReferenceObj (file) {
     var fileObject = {
-        isa: "PBXFileReference",
-        name: "\"" + file.basename + "\"",
-        path: "\"" + file.path.replace(/\\/g, '/') + "\"",
+        isa: 'PBXFileReference',
+        name: '"' + file.basename + '"',
+        path: '"' + file.path.replace(/\\/g, '/') + '"',
         sourceTree: file.sourceTree,
         fileEncoding: file.fileEncoding,
         lastKnownFileType: file.lastKnownFileType,
@@ -1532,7 +1697,7 @@ function pbxFileReferenceObj(file) {
     return fileObject;
 }
 
-function pbxGroupChild(file) {
+function pbxGroupChild (file) {
     var obj = Object.create(null);
 
     obj.value = file.fileRef;
@@ -1541,7 +1706,7 @@ function pbxGroupChild(file) {
     return obj;
 }
 
-function pbxBuildPhaseObj(file) {
+function pbxBuildPhaseObj (file) {
     var obj = Object.create(null);
 
     obj.value = file.uuid;
@@ -1550,9 +1715,13 @@ function pbxBuildPhaseObj(file) {
     return obj;
 }
 
-function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName) {
-
-     // Add additional properties for 'CopyFiles' build phase
+function pbxCopyFilesBuildPhaseObj (
+    obj,
+    folderType,
+    subfolderPath,
+    phaseName
+) {
+    // Add additional properties for 'CopyFiles' build phase
     var DESTINATION_BY_TARGETTYPE = {
         application: 'wrapper',
         app_extension: 'plugins',
@@ -1565,7 +1734,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName) {
         unit_test_bundle: 'wrapper',
         watch_app: 'wrapper',
         watch_extension: 'plugins'
-    }
+    };
     var SUBFOLDERSPEC_BY_DESTINATION = {
         absolute_path: 0,
         executables: 6,
@@ -1578,16 +1747,17 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName) {
         shared_support: 12,
         wrapper: 1,
         xpc_services: 0
-    }
+    };
 
     obj.name = '"' + phaseName + '"';
     obj.dstPath = subfolderPath || '""';
-    obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
+    obj.dstSubfolderSpec =
+        SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 
     return obj;
 }
 
-function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
+function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
     obj.name = '"' + phaseName + '"';
     obj.inputPaths = options.inputPaths || [];
     obj.outputPaths = options.outputPaths || [];
@@ -1597,36 +1767,36 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     return obj;
 }
 
-function pbxBuildFileComment(file) {
+function pbxBuildFileComment (file) {
     return longComment(file);
 }
 
-function pbxFileReferenceComment(file) {
+function pbxFileReferenceComment (file) {
     return file.basename || path.basename(file.path);
 }
 
-function pbxNativeTargetComment(target) {
+function pbxNativeTargetComment (target) {
     return target.name;
 }
 
-function longComment(file) {
-    return f("%s in %s", file.basename, file.group);
+function longComment (file) {
+    return f('%s in %s', file.basename, file.group);
 }
 
 // respect <group> path
-function correctForPluginsPath(file, project) {
+function correctForPluginsPath (file, project) {
     return correctForPath(file, project, 'Plugins');
 }
 
-function correctForResourcesPath(file, project) {
+function correctForResourcesPath (file, project) {
     return correctForPath(file, project, 'Resources');
 }
 
-function correctForFrameworksPath(file, project) {
+function correctForFrameworksPath (file, project) {
     return correctForPath(file, project, 'Frameworks');
 }
 
-function correctForPath(file, project, group) {
+function correctForPath (file, project, group) {
     var r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
     if (project.pbxGroupByName(group).path)
@@ -1635,7 +1805,7 @@ function correctForPath(file, project, group) {
     return file;
 }
 
-function searchPathForFile(file, proj) {
+function searchPathForFile (file, proj) {
     var plugins = proj.pbxGroupByName('Plugins'),
         pluginsPath = plugins ? plugins.path : null,
         fileDir = path.dirname(file.path);
@@ -1655,9 +1825,10 @@ function searchPathForFile(file, proj) {
     }
 }
 
-function nonComments(obj) {
+function nonComments (obj) {
     var keys = Object.keys(obj),
-        newObj = {}, i = 0;
+        newObj = {},
+        i = 0;
 
     for (i; i < keys.length; i++) {
         if (!COMMENT_KEY.test(keys[i])) {
@@ -1668,61 +1839,57 @@ function nonComments(obj) {
     return newObj;
 }
 
-function unquote(str) {
-    if (str) return str.replace(/^"(.*)"$/, "$1");
+function unquote (str) {
+    if (str) return str.replace(/^"(.*)"$/, '$1');
 }
 
-
 function buildPhaseNameForIsa (isa) {
-
     BUILDPHASENAME_BY_ISA = {
         PBXCopyFilesBuildPhase: 'Copy Files',
         PBXResourcesBuildPhase: 'Resources',
         PBXSourcesBuildPhase: 'Sources',
         PBXFrameworksBuildPhase: 'Frameworks'
-    }
+    };
 
-    return BUILDPHASENAME_BY_ISA[isa]
+    return BUILDPHASENAME_BY_ISA[isa];
 }
 
 function producttypeForTargettype (targetType) {
-
     PRODUCTTYPE_BY_TARGETTYPE = {
-            application: 'com.apple.product-type.application',
-            app_extension: 'com.apple.product-type.app-extension',
-            bundle: 'com.apple.product-type.bundle',
-            command_line_tool: 'com.apple.product-type.tool',
-            dynamic_library: 'com.apple.product-type.library.dynamic',
-            framework: 'com.apple.product-type.framework',
-            static_library: 'com.apple.product-type.library.static',
-            unit_test_bundle: 'com.apple.product-type.bundle.unit-test',
-            watch_app: 'com.apple.product-type.application.watchapp',
-            watch_extension: 'com.apple.product-type.watchkit-extension'
-        };
+        application: 'com.apple.product-type.application',
+        app_extension: 'com.apple.product-type.app-extension',
+        bundle: 'com.apple.product-type.bundle',
+        command_line_tool: 'com.apple.product-type.tool',
+        dynamic_library: 'com.apple.product-type.library.dynamic',
+        framework: 'com.apple.product-type.framework',
+        static_library: 'com.apple.product-type.library.static',
+        unit_test_bundle: 'com.apple.product-type.bundle.unit-test',
+        watch_app: 'com.apple.product-type.application.watchapp',
+        watch_extension: 'com.apple.product-type.watchkit-extension'
+    };
 
-    return PRODUCTTYPE_BY_TARGETTYPE[targetType]
+    return PRODUCTTYPE_BY_TARGETTYPE[targetType];
 }
 
 function filetypeForProducttype (productType) {
-
     FILETYPE_BY_PRODUCTTYPE = {
-            'com.apple.product-type.application': '"wrapper.application"',
-            'com.apple.product-type.app-extension': '"wrapper.app-extension"',
-            'com.apple.product-type.bundle': '"wrapper.plug-in"',
-            'com.apple.product-type.tool': '"compiled.mach-o.dylib"',
-            'com.apple.product-type.library.dynamic': '"compiled.mach-o.dylib"',
-            'com.apple.product-type.framework': '"wrapper.framework"',
-            'com.apple.product-type.library.static': '"archive.ar"',
-            'com.apple.product-type.bundle.unit-test': '"wrapper.cfbundle"',
-            'com.apple.product-type.application.watchapp': '"wrapper.application"',
-            'com.apple.product-type.watchkit-extension': '"wrapper.app-extension"'
-        };
+        'com.apple.product-type.application': '"wrapper.application"',
+        'com.apple.product-type.app-extension': '"wrapper.app-extension"',
+        'com.apple.product-type.bundle': '"wrapper.plug-in"',
+        'com.apple.product-type.tool': '"compiled.mach-o.dylib"',
+        'com.apple.product-type.library.dynamic': '"compiled.mach-o.dylib"',
+        'com.apple.product-type.framework': '"wrapper.framework"',
+        'com.apple.product-type.library.static': '"archive.ar"',
+        'com.apple.product-type.bundle.unit-test': '"wrapper.cfbundle"',
+        'com.apple.product-type.application.watchapp':
+            '"wrapper.application"',
+        'com.apple.product-type.watchkit-extension': '"wrapper.app-extension"'
+    };
 
-    return FILETYPE_BY_PRODUCTTYPE[productType]
+    return FILETYPE_BY_PRODUCTTYPE[productType];
 }
 
-pbxProject.prototype.getFirstProject = function() {
-
+pbxProject.prototype.getFirstProject = function () {
     // Get pbxProject container
     var pbxProjectContainer = this.pbxProjectSection();
 
@@ -1732,16 +1899,16 @@ pbxProject.prototype.getFirstProject = function() {
     // Get first pbxProject
     var firstProject = pbxProjectContainer[firstProjectUuid];
 
-     return {
+    return {
         uuid: firstProjectUuid,
         firstProject: firstProject
-    }
-}
+    };
+};
 
-pbxProject.prototype.getFirstTarget = function() {
-
+pbxProject.prototype.getFirstTarget = function () {
     // Get first targets UUID
-    var firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0].value;
+    var firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0]
+        .value;
 
     // Get first pbxNativeTarget
     var firstTarget = this.pbxNativeTargetSection()[firstTargetUuid];
@@ -1749,8 +1916,8 @@ pbxProject.prototype.getFirstTarget = function() {
     return {
         uuid: firstTargetUuid,
         firstTarget: firstTarget
-    }
-}
+    };
+};
 
 /*** NEW ***/
 
@@ -1760,35 +1927,35 @@ pbxProject.prototype.addToPbxGroupType = function (file, groupKey, groupType) {
         if (typeof file === 'string') {
             // Group Key
             var childGroup = {
-                value:file,
+                value: file
             };
             if (this.getPBXGroupByKey(file)) {
                 childGroup.comment = this.getPBXGroupByKey(file).name;
-            }
-            else if (this.getPBXVariantGroupByKey(file)) {
+            } else if (this.getPBXVariantGroupByKey(file)) {
                 childGroup.comment = this.getPBXVariantGroupByKey(file).name;
             }
 
             group.children.push(childGroup);
-        }
-        else {
+        } else {
             // File Object
             group.children.push(pbxGroupChild(file));
         }
     }
-}
+};
 
 pbxProject.prototype.addToPbxVariantGroup = function (file, groupKey) {
     this.addToPbxGroupType(file, groupKey, 'PBXVariantGroup');
-}
+};
 
 pbxProject.prototype.addToPbxGroup = function (file, groupKey) {
     this.addToPbxGroupType(file, groupKey, 'PBXGroup');
-}
+};
 
-
-
-pbxProject.prototype.pbxCreateGroupWithType = function(name, pathName, groupType) {
+pbxProject.prototype.pbxCreateGroupWithType = function (
+    name,
+    pathName,
+    groupType
+) {
     //Create object
     var model = {
         isa: '"' + groupType + '"',
@@ -1811,57 +1978,58 @@ pbxProject.prototype.pbxCreateGroupWithType = function(name, pathName, groupType
     groups[key] = model;
 
     return key;
-}
+};
 
-pbxProject.prototype.pbxCreateVariantGroup = function(name) {
-    return this.pbxCreateGroupWithType(name, undefined, 'PBXVariantGroup')
-}
+pbxProject.prototype.pbxCreateVariantGroup = function (name) {
+    return this.pbxCreateGroupWithType(name, undefined, 'PBXVariantGroup');
+};
 
-pbxProject.prototype.pbxCreateGroup = function(name, pathName) {
+pbxProject.prototype.pbxCreateGroup = function (name, pathName) {
     return this.pbxCreateGroupWithType(name, pathName, 'PBXGroup');
-}
+};
 
-
-
-pbxProject.prototype.removeFromPbxGroupAndType = function (file, groupKey, groupType) {
+pbxProject.prototype.removeFromPbxGroupAndType = function (
+    file,
+    groupKey,
+    groupType
+) {
     var group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group) {
-        var groupChildren = group.children, i;
-        for(i in groupChildren) {
-            if(pbxGroupChild(file).value == groupChildren[i].value &&
-                pbxGroupChild(file).comment == groupChildren[i].comment) {
+        var groupChildren = group.children,
+            i;
+        for (i in groupChildren) {
+            if (
+                pbxGroupChild(file).value == groupChildren[i].value &&
+                pbxGroupChild(file).comment == groupChildren[i].comment
+            ) {
                 groupChildren.splice(i, 1);
                 break;
             }
         }
     }
-}
+};
 
 pbxProject.prototype.removeFromPbxGroup = function (file, groupKey) {
     this.removeFromPbxGroupAndType(file, groupKey, 'PBXGroup');
-}
+};
 
 pbxProject.prototype.removeFromPbxVariantGroup = function (file, groupKey) {
     this.removeFromPbxGroupAndType(file, groupKey, 'PBXVariantGroup');
-}
+};
 
-
-
-pbxProject.prototype.getPBXGroupByKeyAndType = function(key, groupType) {
+pbxProject.prototype.getPBXGroupByKeyAndType = function (key, groupType) {
     return this.hash.project.objects[groupType][key];
 };
 
-pbxProject.prototype.getPBXGroupByKey = function(key) {
+pbxProject.prototype.getPBXGroupByKey = function (key) {
     return this.hash.project.objects['PBXGroup'][key];
 };
 
-pbxProject.prototype.getPBXVariantGroupByKey = function(key) {
+pbxProject.prototype.getPBXVariantGroupByKey = function (key) {
     return this.hash.project.objects['PBXVariantGroup'][key];
 };
 
-
-
-pbxProject.prototype.findPBXGroupKeyAndType = function(criteria, groupType) {
+pbxProject.prototype.findPBXGroupKeyAndType = function (criteria, groupType) {
     var groups = this.hash.project.objects[groupType];
     var target;
 
@@ -1871,47 +2039,48 @@ pbxProject.prototype.findPBXGroupKeyAndType = function(criteria, groupType) {
 
         var group = groups[key];
         if (criteria && criteria.path && criteria.name) {
-            if (criteria.path === group.path && criteria.name === group.name) {
+            if (
+                criteria.path === group.path &&
+                criteria.name === group.name
+            ) {
                 target = key;
-                break
+                break;
             }
-        }
-        else if (criteria && criteria.path) {
+        } else if (criteria && criteria.path) {
             if (criteria.path === group.path) {
                 target = key;
-                break
+                break;
             }
-        }
-        else if (criteria && criteria.name) {
+        } else if (criteria && criteria.name) {
             if (criteria.name === group.name) {
                 target = key;
-                break
+                break;
             }
         }
     }
 
     return target;
-}
+};
 
-pbxProject.prototype.findPBXGroupKey = function(criteria) {
+pbxProject.prototype.findPBXGroupKey = function (criteria) {
     return this.findPBXGroupKeyAndType(criteria, 'PBXGroup');
-}
+};
 
-pbxProject.prototype.findPBXVariantGroupKey = function(criteria) {
+pbxProject.prototype.findPBXVariantGroupKey = function (criteria) {
     return this.findPBXGroupKeyAndType(criteria, 'PBXVariantGroup');
-}
+};
 
-pbxProject.prototype.addLocalizationVariantGroup = function(name) {
+pbxProject.prototype.addLocalizationVariantGroup = function (name) {
     var groupKey = this.pbxCreateVariantGroup(name);
 
-    var resourceGroupKey = this.findPBXGroupKey({name: 'Resources'});
+    var resourceGroupKey = this.findPBXGroupKey({ name: 'Resources' });
     this.addToPbxGroup(groupKey, resourceGroupKey);
 
     var localizationVariantGroup = {
         uuid: this.generateUuid(),
         fileRef: groupKey,
         basename: name
-    }
+    };
     this.addToPbxBuildFileSection(localizationVariantGroup); //    -- PBXBuildFile
     this.addToPbxResourcesBuildPhase(localizationVariantGroup); // -- PBXResourcesBuildPhase
 
@@ -1919,44 +2088,56 @@ pbxProject.prototype.addLocalizationVariantGroup = function(name) {
 };
 
 pbxProject.prototype.addKnownRegion = function (name) {
-  if (!this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions']) {
-    this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions'] = [];
-  }
-  if (!this.hasKnownRegion(name)) {
-    this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions'].push(name);
-  }
-}
+    if (
+        !this.pbxProjectSection()[this.getFirstProject()['uuid']][
+            'knownRegions'
+        ]
+    ) {
+        this.pbxProjectSection()[this.getFirstProject()['uuid']][
+            'knownRegions'
+        ] = [];
+    }
+    if (!this.hasKnownRegion(name)) {
+        this.pbxProjectSection()[this.getFirstProject()['uuid']][
+            'knownRegions'
+        ].push(name);
+    }
+};
 
 pbxProject.prototype.removeKnownRegion = function (name) {
-  var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions'];
-  if (regions) {
-    for (var i = 0; i < regions.length; i++) {
-      if (regions[i] === name) {
-        regions.splice(i, 1);
-        break;
-      }
+    var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
+        'knownRegions'
+    ];
+    if (regions) {
+        for (var i = 0; i < regions.length; i++) {
+            if (regions[i] === name) {
+                regions.splice(i, 1);
+                break;
+            }
+        }
+        this.pbxProjectSection()[this.getFirstProject()['uuid']][
+            'knownRegions'
+        ] = regions;
     }
-    this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions'] = regions;
-  }
-}
+};
 
 pbxProject.prototype.hasKnownRegion = function (name) {
-  var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']]['knownRegions'];
-  if (regions) {
-    for (var i in regions) {
-      if (regions[i] === name) {
-        return true;
-      }
+    var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
+        'knownRegions'
+    ];
+    if (regions) {
+        for (var i in regions) {
+            if (regions[i] === name) {
+                return true;
+            }
+        }
     }
-  }
-  return false;
-}
+    return false;
+};
 
-pbxProject.prototype.getPBXObject = function(name) {
+pbxProject.prototype.getPBXObject = function (name) {
     return this.hash.project.objects[name];
-}
-
-
+};
 
 pbxProject.prototype.addFile = function (path, group, opt) {
     var file = new pbxFile(path, opt);
@@ -1970,13 +2151,12 @@ pbxProject.prototype.addFile = function (path, group, opt) {
 
     if (this.getPBXGroupByKey(group)) {
         this.addToPbxGroup(file, group); //     -- PBXGroup
-    }
-    else if (this.getPBXVariantGroupByKey(group)) {
+    } else if (this.getPBXVariantGroupByKey(group)) {
         this.addToPbxVariantGroup(file, group); // -- PBXVariantGroup
     }
 
     return file;
-}
+};
 
 pbxProject.prototype.removeFile = function (path, group, opt) {
     var file = new pbxFile(path, opt);
@@ -1985,23 +2165,20 @@ pbxProject.prototype.removeFile = function (path, group, opt) {
 
     if (this.getPBXGroupByKey(group)) {
         this.removeFromPbxGroup(file, group); //     -- PBXGroup
-    }
-    else if (this.getPBXVariantGroupByKey(group)) {
+    } else if (this.getPBXVariantGroupByKey(group)) {
         this.removeFromPbxVariantGroup(file, group); // -- PBXVariantGroup
     }
 
     return file;
-}
+};
 
-
-
-pbxProject.prototype.getBuildProperty = function(prop, build) {
+pbxProject.prototype.getBuildProperty = function (prop, build) {
     var target;
     var configs = this.pbxXCBuildConfigurationSection();
     for (var configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
             var config = configs[configName];
-            if ( (build && config.name === build) || (build === undefined) ) {
+            if ((build && config.name === build) || build === undefined) {
                 if (config.buildSettings[prop] !== undefined) {
                     target = config.buildSettings[prop];
                 }
@@ -2009,23 +2186,23 @@ pbxProject.prototype.getBuildProperty = function(prop, build) {
         }
     }
     return target;
-}
+};
 
-pbxProject.prototype.getBuildConfigByName = function(name) {
+pbxProject.prototype.getBuildConfigByName = function (name) {
     var target = {};
     var configs = this.pbxXCBuildConfigurationSection();
     for (var configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
             var config = configs[configName];
-            if (config.name === name)  {
+            if (config.name === name) {
                 target[configName] = config;
             }
         }
     }
     return target;
-}
+};
 
-pbxProject.prototype.addDataModelDocument = function(filePath, group, opt) {
+pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
     if (!group) {
         group = 'Resources';
     }
@@ -2056,7 +2233,8 @@ pbxProject.prototype.addDataModelDocument = function(filePath, group, opt) {
         var modelFilePath = path.join(filePath, modelFileName);
 
         if (modelFileName == '.xccurrentversion') {
-            currentVersionName = plist.readFileSync(modelFilePath)._XCCurrentVersionName;
+            currentVersionName = plist.readFileSync(modelFilePath)
+                ._XCCurrentVersionName;
             continue;
         }
 
@@ -2079,27 +2257,29 @@ pbxProject.prototype.addDataModelDocument = function(filePath, group, opt) {
     this.addToXcVersionGroupSection(file);
 
     return file;
-}
+};
 
-pbxProject.prototype.addTargetAttribute = function(prop, value, target) {
+pbxProject.prototype.addTargetAttribute = function (prop, value, target) {
     var attributes = this.getFirstProject()['firstProject']['attributes'];
     if (attributes['TargetAttributes'] === undefined) {
         attributes['TargetAttributes'] = {};
     }
     target = target || this.getFirstTarget();
     if (attributes['TargetAttributes'][target.uuid] === undefined) {
-      attributes['TargetAttributes'][target.uuid] = {};
+        attributes['TargetAttributes'][target.uuid] = {};
     }
     attributes['TargetAttributes'][target.uuid][prop] = value;
-}
+};
 
-pbxProject.prototype.removeTargetAttribute = function(prop, target) {
+pbxProject.prototype.removeTargetAttribute = function (prop, target) {
     var attributes = this.getFirstProject()['firstProject']['attributes'];
     target = target || this.getFirstTarget();
-    if (attributes['TargetAttributes'] &&
-        attributes['TargetAttributes'][target.uuid]) {
+    if (
+        attributes['TargetAttributes'] &&
+        attributes['TargetAttributes'][target.uuid]
+    ) {
         delete attributes['TargetAttributes'][target.uuid][prop];
     }
-}
+};
 
 module.exports = pbxProject;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -74,10 +74,9 @@ pbxProject.prototype.writeSync = function (options) {
 pbxProject.prototype.allUuids = function () {
     const sections = this.hash.project.objects;
     let uuids = [];
-    let section;
 
     for (key in sections) {
-        section = sections[key];
+        const section = sections[key];
         uuids = uuids.concat(Object.keys(section));
     }
 
@@ -161,12 +160,9 @@ pbxProject.prototype.removeProductFile = function (path, opt) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.addSourceFile = function (path, opt, group) {
-    let file;
-    if (group) {
-        file = this.addFile(path, group, opt);
-    } else {
-        file = this.addPluginFile(path, opt);
-    }
+    const file = group
+        ? this.addFile(path, group, opt)
+        : this.addPluginFile(path, opt);
 
     if (!file) return false;
 
@@ -187,12 +183,10 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.removeSourceFile = function (path, opt, group) {
-    let file;
-    if (group) {
-        file = this.removeFile(path, group, opt);
-    } else {
-        file = this.removePluginFile(path, opt);
-    }
+    const file = group
+        ? this.removeFile(path, group, opt)
+        : this.removePluginFile(path, opt);
+
     file.target = opt ? opt.target : undefined;
     this.removeFromPbxBuildFileSection(file); //  -- PBXBuildFile
     this.removeFromPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
@@ -233,12 +227,12 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
 /**
  *
  * @param path {String}
- * @param opt {Object} see pbxFile for avail options
+ * @param opts {Object} see pbxFile for avail options
  * @param group {String} group key
  * @returns {Object} file; see pbxFile
  */
-pbxProject.prototype.addResourceFile = function (path, opt, group) {
-    opt = opt || {};
+pbxProject.prototype.addResourceFile = function (path, opts, group) {
+    const opt = opts || {};
 
     let file;
 
@@ -442,8 +436,8 @@ pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
     }
 };
 
-pbxProject.prototype.addStaticLibrary = function (path, opt) {
-    opt = opt || {};
+pbxProject.prototype.addStaticLibrary = function (path, opts) {
+    const opt = opts || {};
 
     let file;
 
@@ -479,9 +473,7 @@ pbxProject.prototype.addToPbxBuildFileSection = function (file) {
 };
 
 pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
-    let uuid;
-
-    for (uuid in this.pbxBuildFileSection()) {
+    for (const uuid in this.pbxBuildFileSection()) {
         if (
             this.pbxBuildFileSection()[uuid].fileRef_comment === file.basename
         ) {
@@ -526,7 +518,7 @@ pbxProject.prototype.addPbxGroup = function (
         };
     }
 
-    for (let index = 0; index < filePathsArray.length; index++) {
+    for (const index in filePathsArray) {
         const filePath = filePathsArray[index];
         const filePathQuoted = '"' + filePath + '"';
         if (filePathToReference[filePath]) {
@@ -559,15 +551,13 @@ pbxProject.prototype.addPbxGroup = function (
 
 pbxProject.prototype.removePbxGroup = function (groupName) {
     const section = this.hash.project.objects['PBXGroup'];
-    let key;
-    let itemKey;
 
-    for (key in section) {
+    for (const key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (section[key] === groupName) {
-            itemKey = key.split(COMMENT_KEY)[0];
+            const itemKey = key.split(COMMENT_KEY)[0];
             delete section[itemKey];
         }
     }
@@ -601,9 +591,9 @@ pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
 };
 
 pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
-    let i;
     const refObj = pbxFileReferenceObj(file);
-    for (i in this.pbxFileReferenceSection()) {
+
+    for (const i in this.pbxFileReferenceSection()) {
         if (
             this.pbxFileReferenceSection()[i].name === refObj.name ||
             '"' + this.pbxFileReferenceSection()[i].name + '"' ===
@@ -663,8 +653,7 @@ pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
         return null;
     }
     const pluginsGroupChildren = this.pbxGroupByName('Plugins').children;
-    let i;
-    for (i in pluginsGroupChildren) {
+    for (const i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
             pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
@@ -689,8 +678,7 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
         return null;
     }
     const pluginsGroupChildren = this.pbxGroupByName('Resources').children;
-    let i;
-    for (i in pluginsGroupChildren) {
+    for (const i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
             pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
@@ -761,8 +749,7 @@ pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
         return null;
     }
     const productsGroupChildren = this.pbxGroupByName('Products').children;
-    let i;
-    for (i in productsGroupChildren) {
+    for (const i in productsGroupChildren) {
         if (
             pbxGroupChild(file).value === productsGroupChildren[i].value &&
             pbxGroupChild(file).comment === productsGroupChildren[i].comment
@@ -780,8 +767,7 @@ pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
 
 pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
     const sources = this.pbxSourcesBuildPhaseObj(file.target);
-    let i;
-    for (i in sources.files) {
+    for (const i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
@@ -796,9 +782,8 @@ pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
 
 pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
     const sources = this.pbxResourcesBuildPhaseObj(file.target);
-    let i;
 
-    for (i in sources.files) {
+    for (const i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
@@ -837,7 +822,7 @@ pbxProject.prototype.addXCConfigurationList = function (
         defaultConfigurationName: defaultConfigurationName
     };
 
-    for (let index = 0; index < configurationObjectsArray.length; index++) {
+    for (index = 0; index < configurationObjectsArray.length; index++) {
         const configuration = configurationObjectsArray[index];
         const configurationUuid = this.generateUuid();
         const configurationCommentKey = f('%s_comment', configurationUuid);
@@ -891,7 +876,7 @@ pbxProject.prototype.addTargetDependency = function (
         pbxContainerItemProxy
     ];
 
-    for (let index = 0; index < dependencyTargets.length; index++) {
+    for (const index in dependencyTargets) {
         const dependencyTargetUuid = dependencyTargets[index];
         const dependencyTargetCommentKey = f(
             '%s_comment',
@@ -951,18 +936,21 @@ pbxProject.prototype.addBuildPhase = function (
     optionsOrFolderType,
     subfolderPath
 ) {
-    let buildPhaseSection;
     const fileReferenceSection = this.pbxFileReferenceSection();
     const buildFileSection = this.pbxBuildFileSection();
     const buildPhaseUuid = this.generateUuid();
     const buildPhaseTargetUuid = target || this.getFirstTarget().uuid;
     const commentKey = f('%s_comment', buildPhaseUuid);
+
+    let buildPhaseSection;
+
     let buildPhase = {
         isa: buildPhaseType,
         buildActionMask: 2147483647,
         files: [],
         runOnlyForDeploymentPostprocessing: 0
     };
+
     const filePathToBuildFile = {};
 
     if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
@@ -1023,7 +1011,7 @@ pbxProject.prototype.addBuildPhase = function (
         };
     }
 
-    for (let index = 0; index < filePathsArray.length; index++) {
+    for (const index in filePathsArray) {
         const filePath = filePathsArray[index];
         const filePathQuoted = '"' + filePath + '"';
         const file = new pbxFile(filePath);
@@ -1089,15 +1077,13 @@ pbxProject.prototype.pbxXCConfigurationList = function () {
 
 pbxProject.prototype.pbxGroupByName = function (name) {
     const groups = this.hash.project.objects['PBXGroup'];
-    let key;
-    let groupKey;
 
-    for (key in groups) {
+    for (const key in groups) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (groups[key] === name) {
-            groupKey = key.split(COMMENT_KEY)[0];
+            const groupKey = key.split(COMMENT_KEY)[0];
             return groups[groupKey];
         }
     }
@@ -1127,15 +1113,13 @@ pbxProject.prototype.findTargetKey = function (name) {
 
 pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
     const section = this.hash.project.objects[pbxSectionName];
-    let key;
-    let itemKey;
 
-    for (key in section) {
+    for (const key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (section[key] === name) {
-            itemKey = key.split(COMMENT_KEY)[0];
+            const itemKey = key.split(COMMENT_KEY)[0];
             return section[itemKey];
         }
     }
@@ -1192,19 +1176,17 @@ pbxProject.prototype.buildPhase = function (group, target) {
 
 pbxProject.prototype.buildPhaseObject = function (name, group, target) {
     const section = this.hash.project.objects[name];
-    let obj;
-    let sectionKey;
-    let key;
+
     const buildPhase = this.buildPhase(group, target);
 
-    for (key in section) {
+    for (const key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         // select the proper buildPhase
         if (buildPhase && buildPhase !== key) continue;
         if (section[key] === group) {
-            sectionKey = key.split(COMMENT_KEY)[0];
+            const sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
     }
@@ -1213,11 +1195,9 @@ pbxProject.prototype.buildPhaseObject = function (name, group, target) {
 
 pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
-    let key;
-    let configuration;
 
-    for (key in configurations) {
-        configuration = configurations[key];
+    for (const key in configurations) {
+        const configuration = configurations[key];
         if (!build_name || configuration.name === build_name) {
             configuration.buildSettings[prop] = value;
         }
@@ -1226,11 +1206,9 @@ pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
 
 pbxProject.prototype.removeBuildProperty = function (prop, build_name) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
-    let key;
-    let configuration;
 
-    for (key in configurations) {
-        configuration = configurations[key];
+    for (const key in configurations) {
+        const configuration = configurations[key];
         if (
             (configuration.buildSettings[prop] && !build_name) ||
             configuration.name === build_name
@@ -1266,19 +1244,17 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS';
-    let config;
-    let buildSettings;
-    let searchPaths;
+
     const new_path = searchPathForFile(file, this);
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
-        searchPaths = buildSettings[SEARCH_PATHS];
+        const searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
             const matches = searchPaths.filter(function (p) {
@@ -1295,12 +1271,9 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
 pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
-    let config;
-    let buildSettings;
-    let searchPaths;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1323,19 +1296,17 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS';
-    let config;
-    let buildSettings;
-    let searchPaths;
+
     const new_path = searchPathForFile(file, this);
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
-        searchPaths = buildSettings[SEARCH_PATHS];
+        const searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
             const matches = searchPaths.filter(function (p) {
@@ -1352,12 +1323,9 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
 pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
-    let config;
-    let buildSettings;
-    let searchPaths;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1384,13 +1352,11 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'HEADER_SEARCH_PATHS';
-    let config;
-    let buildSettings;
-    let searchPaths;
+
     const new_path = searchPathForFile(file, this);
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1410,12 +1376,9 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
 pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
-    let config;
-    let buildSettings;
-    let searchPaths;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1439,11 +1402,9 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
-    let config;
-    let buildSettings;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1463,11 +1424,9 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
 pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
-    let config;
-    let buildSettings;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1487,11 +1446,9 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
 
 pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
-    let config;
-    let buildSettings;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         buildSettings[buildSetting] = value;
     }
@@ -1499,11 +1456,9 @@ pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
 
 pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
-    let config;
-    let buildSettings;
 
-    for (config in configurations) {
-        buildSettings = configurations[config].buildSettings;
+    for (const config in configurations) {
+        const buildSettings = configurations[config].buildSettings;
 
         if (buildSettings[buildSetting]) {
             delete buildSettings[buildSetting];
@@ -1514,11 +1469,9 @@ pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
 // a JS getter. hmmm
 pbxProject.prototype.__defineGetter__('productName', function () {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
-    let config;
-    let productName;
 
-    for (config in configurations) {
-        productName = configurations[config].buildSettings['PRODUCT_NAME'];
+    for (const config in configurations) {
+        const productName = configurations[config].buildSettings['PRODUCT_NAME'];
 
         if (productName) {
             return unquote(productName);
@@ -1529,10 +1482,9 @@ pbxProject.prototype.__defineGetter__('productName', function () {
 // check if file is present
 pbxProject.prototype.hasFile = function (filePath) {
     const files = nonComments(this.pbxFileReferenceSection());
-    let file;
-    let id;
-    for (id in files) {
-        file = files[id];
+
+    for (const id in files) {
+        const file = files[id];
         if (file.path === filePath || file.path === '"' + filePath + '"') {
             return file;
         }
@@ -1820,6 +1772,7 @@ function correctForPath (file, project, group) {
 function searchPathForFile (file, proj) {
     const plugins = proj.pbxGroupByName('Plugins');
     const pluginsPath = plugins ? plugins.path : null;
+
     let fileDir = path.dirname(file.path);
 
     if (fileDir === '.') {
@@ -1840,9 +1793,8 @@ function searchPathForFile (file, proj) {
 function nonComments (obj) {
     const keys = Object.keys(obj);
     const newObj = {};
-    let i = 0;
 
-    for (i; i < keys.length; i++) {
+    for (const i in keys) {
         if (!COMMENT_KEY.test(keys[i])) {
             newObj[keys[i]] = obj[keys[i]];
         }
@@ -2008,8 +1960,8 @@ pbxProject.prototype.removeFromPbxGroupAndType = function (
     const group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group) {
         const groupChildren = group.children;
-        let i;
-        for (i in groupChildren) {
+
+        for (const i in groupChildren) {
             if (
                 pbxGroupChild(file).value === groupChildren[i].value &&
                 pbxGroupChild(file).comment === groupChildren[i].comment
@@ -2043,6 +1995,7 @@ pbxProject.prototype.getPBXVariantGroupByKey = function (key) {
 
 pbxProject.prototype.findPBXGroupKeyAndType = function (criteria, groupType) {
     const groups = this.hash.project.objects[groupType];
+
     let target;
 
     for (const key in groups) {
@@ -2121,7 +2074,7 @@ pbxProject.prototype.removeKnownRegion = function (name) {
         'knownRegions'
     ];
     if (regions) {
-        for (let i = 0; i < regions.length; i++) {
+        for (const i in regions) {
             if (regions[i] === name) {
                 regions.splice(i, 1);
                 break;
@@ -2185,8 +2138,9 @@ pbxProject.prototype.removeFile = function (path, group, opt) {
 };
 
 pbxProject.prototype.getBuildProperty = function (prop, build) {
-    let target;
     const configs = this.pbxXCBuildConfigurationSection();
+    let target;
+
     for (const configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
             const config = configs[configName];
@@ -2238,8 +2192,11 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
     this.addToPbxSourcesBuildPhase(file);
 
     file.models = [];
+
     let currentVersionName;
+
     const modelFiles = fs.readdirSync(file.path);
+
     for (const index in modelFiles) {
         const modelFileName = modelFiles[index];
         const modelFilePath = path.join(filePath, modelFileName);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -37,7 +37,7 @@ function pbxProject (filename) {
 util.inherits(pbxProject, EventEmitter);
 
 pbxProject.prototype.parse = function (cb) {
-    var worker = fork(__dirname + '/parseJob.js', [this.filepath]);
+    var worker = fork(path.join(__dirname, '/parseJob.js'), [this.filepath]);
 
     worker.on(
         'message',

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1930,7 +1930,7 @@ pbxProject.prototype.getFirstTarget = function () {
     };
 };
 
-/*** NEW ***/
+/** ** NEW ** **/
 
 pbxProject.prototype.addToPbxGroupType = function (file, groupKey, groupType) {
     var group = this.getPBXGroupByKeyAndType(groupKey, groupType);
@@ -1967,7 +1967,7 @@ pbxProject.prototype.pbxCreateGroupWithType = function (
     pathName,
     groupType
 ) {
-    //Create object
+    // Create object
     var model = {
         isa: '"' + groupType + '"',
         children: [],
@@ -1977,10 +1977,10 @@ pbxProject.prototype.pbxCreateGroupWithType = function (
     if (pathName) model.path = pathName;
     var key = this.generateUuid();
 
-    //Create comment
+    // Create comment
     var commendId = key + '_comment';
 
-    //add obj and commentObj to groups;
+    // add obj and commentObj to groups;
     var groups = this.hash.project.objects[groupType];
     if (!groups) {
         groups = this.hash.project.objects[groupType] = new Object();

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -42,7 +42,7 @@ pbxProject.prototype.parse = function (cb) {
     worker.on(
         'message',
         function (msg) {
-            if (msg.name == 'SyntaxError' || msg.code) {
+            if (msg.name === 'SyntaxError' || msg.code) {
                 this.emit('error', msg);
             } else {
                 this.hash = msg;
@@ -82,7 +82,7 @@ pbxProject.prototype.allUuids = function () {
     }
 
     uuids = uuids.filter(function (str) {
-        return !COMMENT_KEY.test(str) && str.length == 24;
+        return !COMMENT_KEY.test(str) && str.length === 24;
     });
 
     return uuids;
@@ -309,8 +309,8 @@ pbxProject.prototype.removeResourceFile = function (path, opt, group) {
 };
 
 pbxProject.prototype.addFramework = function (fpath, opt) {
-    var customFramework = opt && opt.customFramework == true;
-    var link = !opt || (opt.link == undefined || opt.link); // -- defaults to true if not specified
+    var customFramework = opt && opt.customFramework === true;
+    var link = !opt || (opt.link === undefined || opt.link); // -- defaults to true if not specified
     var embed = opt && opt.embed; //                           -- defaults to false if not specified
 
     if (opt) {
@@ -435,7 +435,7 @@ pbxProject.prototype.removeCopyfile = function (fpath, opt) {
 pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
     var sources = this.pbxCopyfilesBuildPhaseObj(file.target);
     for (i in sources.files) {
-        if (sources.files[i].comment == longComment(file)) {
+        if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
@@ -483,7 +483,7 @@ pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
 
     for (uuid in this.pbxBuildFileSection()) {
         if (
-            this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename
+            this.pbxBuildFileSection()[uuid].fileRef_comment === file.basename
         ) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
@@ -566,7 +566,7 @@ pbxProject.prototype.removePbxGroup = function (groupName) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        if (section[key] == groupName) {
+        if (section[key] === groupName) {
             itemKey = key.split(COMMENT_KEY)[0];
             delete section[itemKey];
         }
@@ -605,11 +605,11 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
     var refObj = pbxFileReferenceObj(file);
     for (i in this.pbxFileReferenceSection()) {
         if (
-            this.pbxFileReferenceSection()[i].name == refObj.name ||
-            '"' + this.pbxFileReferenceSection()[i].name + '"' ==
+            this.pbxFileReferenceSection()[i].name === refObj.name ||
+            '"' + this.pbxFileReferenceSection()[i].name + '"' ===
                 refObj.name ||
-            this.pbxFileReferenceSection()[i].path == refObj.path ||
-            '"' + this.pbxFileReferenceSection()[i].path + '"' == refObj.path
+            this.pbxFileReferenceSection()[i].path === refObj.path ||
+            '"' + this.pbxFileReferenceSection()[i].path + '"' === refObj.path
         ) {
             file.fileRef = file.uuid = i;
             delete this.pbxFileReferenceSection()[i];
@@ -617,7 +617,7 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
         }
     }
     var commentKey = f('%s_comment', file.fileRef);
-    if (this.pbxFileReferenceSection()[commentKey] != undefined) {
+    if (this.pbxFileReferenceSection()[commentKey] !== undefined) {
         delete this.pbxFileReferenceSection()[commentKey];
     }
 
@@ -666,8 +666,8 @@ pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
         i;
     for (i in pluginsGroupChildren) {
         if (
-            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+            pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
         ) {
             pluginsGroupChildren.splice(i, 1);
             break;
@@ -692,8 +692,8 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
         i;
     for (i in pluginsGroupChildren) {
         if (
-            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+            pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
         ) {
             pluginsGroupChildren.splice(i, 1);
             break;
@@ -718,8 +718,8 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
 
     for (i in pluginsGroupChildren) {
         if (
-            pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment
+            pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
         ) {
             pluginsGroupChildren.splice(i, 1);
             break;
@@ -739,7 +739,7 @@ pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
     if (sources) {
         var files = [];
         for (i in sources.files) {
-            if (sources.files[i].comment != longComment(file)) {
+            if (sources.files[i].comment !== longComment(file)) {
                 files.push(sources.files[i]);
             }
         }
@@ -764,8 +764,8 @@ pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
         i;
     for (i in productsGroupChildren) {
         if (
-            pbxGroupChild(file).value == productsGroupChildren[i].value &&
-            pbxGroupChild(file).comment == productsGroupChildren[i].comment
+            pbxGroupChild(file).value === productsGroupChildren[i].value &&
+            pbxGroupChild(file).comment === productsGroupChildren[i].comment
         ) {
             productsGroupChildren.splice(i, 1);
             break;
@@ -782,7 +782,7 @@ pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
     var sources = this.pbxSourcesBuildPhaseObj(file.target),
         i;
     for (i in sources.files) {
-        if (sources.files[i].comment == longComment(file)) {
+        if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
@@ -799,7 +799,7 @@ pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
         i;
 
     for (i in sources.files) {
-        if (sources.files[i].comment == longComment(file)) {
+        if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
@@ -814,7 +814,7 @@ pbxProject.prototype.addToPbxFrameworksBuildPhase = function (file) {
 pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
     for (i in sources.files) {
-        if (sources.files[i].comment == longComment(file)) {
+        if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
@@ -872,13 +872,13 @@ pbxProject.prototype.addTargetDependency = function (
 
     var nativeTargets = this.pbxNativeTargetSection();
 
-    if (typeof nativeTargets[target] == 'undefined') {
+    if (typeof nativeTargets[target] === 'undefined') {
         throw new Error('Invalid target: ' + target);
     }
 
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTarget = dependencyTargets[index];
-        if (typeof nativeTargets[dependencyTarget] == 'undefined') {
+        if (typeof nativeTargets[dependencyTarget] === 'undefined') {
             throw new Error('Invalid target: ' + dependencyTarget);
         }
     }
@@ -1097,7 +1097,7 @@ pbxProject.prototype.pbxGroupByName = function (name) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        if (groups[key] == name) {
+        if (groups[key] === name) {
             groupKey = key.split(COMMENT_KEY)[0];
             return groups[groupKey];
         }
@@ -1135,7 +1135,7 @@ pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        if (section[key] == name) {
+        if (section[key] === name) {
             itemKey = key.split(COMMENT_KEY)[0];
             return section[itemKey];
         }
@@ -1177,7 +1177,7 @@ pbxProject.prototype.buildPhase = function (group, target) {
     if (!target) return undefined;
 
     var nativeTargets = this.pbxNativeTargetSection();
-    if (typeof nativeTargets[target] == 'undefined') {
+    if (typeof nativeTargets[target] === 'undefined') {
         throw new Error('Invalid target: ' + target);
     }
 
@@ -1185,7 +1185,7 @@ pbxProject.prototype.buildPhase = function (group, target) {
     var buildPhases = nativeTarget.buildPhases;
     for (var i in buildPhases) {
         var buildPhase = buildPhases[i];
-        if (buildPhase.comment == group) return buildPhase.value + '_comment';
+        if (buildPhase.comment === group) return buildPhase.value + '_comment';
     }
 };
 
@@ -1201,8 +1201,8 @@ pbxProject.prototype.buildPhaseObject = function (name, group, target) {
         if (!COMMENT_KEY.test(key)) continue;
 
         // select the proper buildPhase
-        if (buildPhase && buildPhase != key) continue;
-        if (section[key] == group) {
+        if (buildPhase && buildPhase !== key) continue;
+        if (section[key] === group) {
             sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
@@ -1273,7 +1273,7 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1301,7 +1301,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1330,7 +1330,7 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1358,7 +1358,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1391,7 +1391,7 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1416,7 +1416,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1444,7 +1444,7 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1468,7 +1468,7 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+        if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
@@ -1532,7 +1532,7 @@ pbxProject.prototype.hasFile = function (filePath) {
         id;
     for (id in files) {
         file = files[id];
-        if (file.path == filePath || file.path == '"' + filePath + '"') {
+        if (file.path === filePath || file.path === '"' + filePath + '"') {
             return file;
         }
     }
@@ -1671,9 +1671,9 @@ function propReplace (obj, prop, value) {
     var o = {};
     for (var p in obj) {
         if (o.hasOwnProperty.call(obj, p)) {
-            if (typeof obj[p] == 'object' && !Array.isArray(obj[p])) {
+            if (typeof obj[p] === 'object' && !Array.isArray(obj[p])) {
                 propReplace(obj[p], prop, value);
-            } else if (p == prop) {
+            } else if (p === prop) {
                 obj[p] = value;
             }
         }
@@ -1821,7 +1821,7 @@ function searchPathForFile (file, proj) {
         pluginsPath = plugins ? plugins.path : null,
         fileDir = path.dirname(file.path);
 
-    if (fileDir == '.') {
+    if (fileDir === '.') {
         fileDir = '';
     } else {
         fileDir = '/' + fileDir;
@@ -2010,8 +2010,8 @@ pbxProject.prototype.removeFromPbxGroupAndType = function (
             i;
         for (i in groupChildren) {
             if (
-                pbxGroupChild(file).value == groupChildren[i].value &&
-                pbxGroupChild(file).comment == groupChildren[i].comment
+                pbxGroupChild(file).value === groupChildren[i].value &&
+                pbxGroupChild(file).comment === groupChildren[i].comment
             ) {
                 groupChildren.splice(i, 1);
                 break;
@@ -2243,7 +2243,7 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
         var modelFileName = modelFiles[index];
         var modelFilePath = path.join(filePath, modelFileName);
 
-        if (modelFileName == '.xccurrentversion') {
+        if (modelFileName === '.xccurrentversion') {
             currentVersionName = plist.readFileSync(modelFilePath)
                 ._XCCurrentVersionName;
             continue;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -74,9 +74,10 @@ pbxProject.prototype.writeSync = function (options) {
 pbxProject.prototype.allUuids = function () {
     const sections = this.hash.project.objects;
     let uuids = [];
+    let section;
 
     for (key in sections) {
-        const section = sections[key];
+        section = sections[key];
         uuids = uuids.concat(Object.keys(section));
     }
 
@@ -160,9 +161,12 @@ pbxProject.prototype.removeProductFile = function (path, opt) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.addSourceFile = function (path, opt, group) {
-    const file = group
-        ? this.addFile(path, group, opt)
-        : this.addPluginFile(path, opt);
+    let file;
+    if (group) {
+        file = this.addFile(path, group, opt);
+    } else {
+        file = this.addPluginFile(path, opt);
+    }
 
     if (!file) return false;
 
@@ -183,10 +187,12 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.removeSourceFile = function (path, opt, group) {
-    const file = group
-        ? this.removeFile(path, group, opt)
-        : this.removePluginFile(path, opt);
-
+    let file;
+    if (group) {
+        file = this.removeFile(path, group, opt);
+    } else {
+        file = this.removePluginFile(path, opt);
+    }
     file.target = opt ? opt.target : undefined;
     this.removeFromPbxBuildFileSection(file); //  -- PBXBuildFile
     this.removeFromPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
@@ -227,12 +233,12 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
 /**
  *
  * @param path {String}
- * @param opts {Object} see pbxFile for avail options
+ * @param opt {Object} see pbxFile for avail options
  * @param group {String} group key
  * @returns {Object} file; see pbxFile
  */
-pbxProject.prototype.addResourceFile = function (path, opts, group) {
-    const opt = opts || {};
+pbxProject.prototype.addResourceFile = function (path, opt, group) {
+    opt = opt || {};
 
     let file;
 
@@ -436,8 +442,8 @@ pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
     }
 };
 
-pbxProject.prototype.addStaticLibrary = function (path, opts) {
-    const opt = opts || {};
+pbxProject.prototype.addStaticLibrary = function (path, opt) {
+    opt = opt || {};
 
     let file;
 
@@ -473,7 +479,9 @@ pbxProject.prototype.addToPbxBuildFileSection = function (file) {
 };
 
 pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
-    for (const uuid in this.pbxBuildFileSection()) {
+    let uuid;
+
+    for (uuid in this.pbxBuildFileSection()) {
         if (
             this.pbxBuildFileSection()[uuid].fileRef_comment === file.basename
         ) {
@@ -518,7 +526,7 @@ pbxProject.prototype.addPbxGroup = function (
         };
     }
 
-    for (const index in filePathsArray) {
+    for (let index = 0; index < filePathsArray.length; index++) {
         const filePath = filePathsArray[index];
         const filePathQuoted = '"' + filePath + '"';
         if (filePathToReference[filePath]) {
@@ -551,13 +559,15 @@ pbxProject.prototype.addPbxGroup = function (
 
 pbxProject.prototype.removePbxGroup = function (groupName) {
     const section = this.hash.project.objects['PBXGroup'];
+    let key;
+    let itemKey;
 
-    for (const key in section) {
+    for (key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (section[key] === groupName) {
-            const itemKey = key.split(COMMENT_KEY)[0];
+            itemKey = key.split(COMMENT_KEY)[0];
             delete section[itemKey];
         }
     }
@@ -591,9 +601,9 @@ pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
 };
 
 pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
+    let i;
     const refObj = pbxFileReferenceObj(file);
-
-    for (const i in this.pbxFileReferenceSection()) {
+    for (i in this.pbxFileReferenceSection()) {
         if (
             this.pbxFileReferenceSection()[i].name === refObj.name ||
             '"' + this.pbxFileReferenceSection()[i].name + '"' ===
@@ -653,7 +663,8 @@ pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
         return null;
     }
     const pluginsGroupChildren = this.pbxGroupByName('Plugins').children;
-    for (const i in pluginsGroupChildren) {
+    let i;
+    for (i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
             pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
@@ -678,7 +689,8 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
         return null;
     }
     const pluginsGroupChildren = this.pbxGroupByName('Resources').children;
-    for (const i in pluginsGroupChildren) {
+    let i;
+    for (i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
             pbxGroupChild(file).comment === pluginsGroupChildren[i].comment
@@ -749,7 +761,8 @@ pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
         return null;
     }
     const productsGroupChildren = this.pbxGroupByName('Products').children;
-    for (const i in productsGroupChildren) {
+    let i;
+    for (i in productsGroupChildren) {
         if (
             pbxGroupChild(file).value === productsGroupChildren[i].value &&
             pbxGroupChild(file).comment === productsGroupChildren[i].comment
@@ -767,7 +780,8 @@ pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
 
 pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
     const sources = this.pbxSourcesBuildPhaseObj(file.target);
-    for (const i in sources.files) {
+    let i;
+    for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
@@ -782,8 +796,9 @@ pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
 
 pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
     const sources = this.pbxResourcesBuildPhaseObj(file.target);
+    let i;
 
-    for (const i in sources.files) {
+    for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
             break;
@@ -822,7 +837,7 @@ pbxProject.prototype.addXCConfigurationList = function (
         defaultConfigurationName: defaultConfigurationName
     };
 
-    for (index = 0; index < configurationObjectsArray.length; index++) {
+    for (let index = 0; index < configurationObjectsArray.length; index++) {
         const configuration = configurationObjectsArray[index];
         const configurationUuid = this.generateUuid();
         const configurationCommentKey = f('%s_comment', configurationUuid);
@@ -876,7 +891,7 @@ pbxProject.prototype.addTargetDependency = function (
         pbxContainerItemProxy
     ];
 
-    for (const index in dependencyTargets) {
+    for (let index = 0; index < dependencyTargets.length; index++) {
         const dependencyTargetUuid = dependencyTargets[index];
         const dependencyTargetCommentKey = f(
             '%s_comment',
@@ -936,21 +951,18 @@ pbxProject.prototype.addBuildPhase = function (
     optionsOrFolderType,
     subfolderPath
 ) {
+    let buildPhaseSection;
     const fileReferenceSection = this.pbxFileReferenceSection();
     const buildFileSection = this.pbxBuildFileSection();
     const buildPhaseUuid = this.generateUuid();
     const buildPhaseTargetUuid = target || this.getFirstTarget().uuid;
     const commentKey = f('%s_comment', buildPhaseUuid);
-
-    let buildPhaseSection;
-
     let buildPhase = {
         isa: buildPhaseType,
         buildActionMask: 2147483647,
         files: [],
         runOnlyForDeploymentPostprocessing: 0
     };
-
     const filePathToBuildFile = {};
 
     if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
@@ -1011,7 +1023,7 @@ pbxProject.prototype.addBuildPhase = function (
         };
     }
 
-    for (const index in filePathsArray) {
+    for (let index = 0; index < filePathsArray.length; index++) {
         const filePath = filePathsArray[index];
         const filePathQuoted = '"' + filePath + '"';
         const file = new pbxFile(filePath);
@@ -1077,13 +1089,15 @@ pbxProject.prototype.pbxXCConfigurationList = function () {
 
 pbxProject.prototype.pbxGroupByName = function (name) {
     const groups = this.hash.project.objects['PBXGroup'];
+    let key;
+    let groupKey;
 
-    for (const key in groups) {
+    for (key in groups) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (groups[key] === name) {
-            const groupKey = key.split(COMMENT_KEY)[0];
+            groupKey = key.split(COMMENT_KEY)[0];
             return groups[groupKey];
         }
     }
@@ -1113,13 +1127,15 @@ pbxProject.prototype.findTargetKey = function (name) {
 
 pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
     const section = this.hash.project.objects[pbxSectionName];
+    let key;
+    let itemKey;
 
-    for (const key in section) {
+    for (key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         if (section[key] === name) {
-            const itemKey = key.split(COMMENT_KEY)[0];
+            itemKey = key.split(COMMENT_KEY)[0];
             return section[itemKey];
         }
     }
@@ -1176,17 +1192,19 @@ pbxProject.prototype.buildPhase = function (group, target) {
 
 pbxProject.prototype.buildPhaseObject = function (name, group, target) {
     const section = this.hash.project.objects[name];
-
+    let obj;
+    let sectionKey;
+    let key;
     const buildPhase = this.buildPhase(group, target);
 
-    for (const key in section) {
+    for (key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
         // select the proper buildPhase
         if (buildPhase && buildPhase !== key) continue;
         if (section[key] === group) {
-            const sectionKey = key.split(COMMENT_KEY)[0];
+            sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
     }
@@ -1195,9 +1213,11 @@ pbxProject.prototype.buildPhaseObject = function (name, group, target) {
 
 pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let key;
+    let configuration;
 
-    for (const key in configurations) {
-        const configuration = configurations[key];
+    for (key in configurations) {
+        configuration = configurations[key];
         if (!build_name || configuration.name === build_name) {
             configuration.buildSettings[prop] = value;
         }
@@ -1206,9 +1226,11 @@ pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
 
 pbxProject.prototype.removeBuildProperty = function (prop, build_name) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let key;
+    let configuration;
 
-    for (const key in configurations) {
-        const configuration = configurations[key];
+    for (key in configurations) {
+        configuration = configurations[key];
         if (
             (configuration.buildSettings[prop] && !build_name) ||
             configuration.name === build_name
@@ -1244,17 +1266,19 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS';
-
+    let config;
+    let buildSettings;
+    let searchPaths;
     const new_path = searchPathForFile(file, this);
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
-        const searchPaths = buildSettings[SEARCH_PATHS];
+        searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
             const matches = searchPaths.filter(function (p) {
@@ -1271,9 +1295,12 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
 pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1296,17 +1323,19 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS';
-
+    let config;
+    let buildSettings;
+    let searchPaths;
     const new_path = searchPathForFile(file, this);
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
         }
 
-        const searchPaths = buildSettings[SEARCH_PATHS];
+        searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
             const matches = searchPaths.filter(function (p) {
@@ -1323,9 +1352,12 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
 pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1352,11 +1384,13 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const SEARCH_PATHS = 'HEADER_SEARCH_PATHS';
-
+    let config;
+    let buildSettings;
+    let searchPaths;
     const new_path = searchPathForFile(file, this);
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1376,9 +1410,12 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
 pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1402,9 +1439,11 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const INHERITED = '"$(inherited)"';
     const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
+    let config;
+    let buildSettings;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1424,9 +1463,11 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
 pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
     const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
+    let config;
+    let buildSettings;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (unquote(buildSettings['PRODUCT_NAME']) !== this.productName) {
             continue;
@@ -1446,9 +1487,11 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
 
 pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let buildSettings;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         buildSettings[buildSetting] = value;
     }
@@ -1456,9 +1499,11 @@ pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
 
 pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let buildSettings;
 
-    for (const config in configurations) {
-        const buildSettings = configurations[config].buildSettings;
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
 
         if (buildSettings[buildSetting]) {
             delete buildSettings[buildSetting];
@@ -1469,9 +1514,11 @@ pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
 // a JS getter. hmmm
 pbxProject.prototype.__defineGetter__('productName', function () {
     const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let productName;
 
-    for (const config in configurations) {
-        const productName = configurations[config].buildSettings['PRODUCT_NAME'];
+    for (config in configurations) {
+        productName = configurations[config].buildSettings['PRODUCT_NAME'];
 
         if (productName) {
             return unquote(productName);
@@ -1482,9 +1529,10 @@ pbxProject.prototype.__defineGetter__('productName', function () {
 // check if file is present
 pbxProject.prototype.hasFile = function (filePath) {
     const files = nonComments(this.pbxFileReferenceSection());
-
-    for (const id in files) {
-        const file = files[id];
+    let file;
+    let id;
+    for (id in files) {
+        file = files[id];
         if (file.path === filePath || file.path === '"' + filePath + '"') {
             return file;
         }
@@ -1772,7 +1820,6 @@ function correctForPath (file, project, group) {
 function searchPathForFile (file, proj) {
     const plugins = proj.pbxGroupByName('Plugins');
     const pluginsPath = plugins ? plugins.path : null;
-
     let fileDir = path.dirname(file.path);
 
     if (fileDir === '.') {
@@ -1793,8 +1840,9 @@ function searchPathForFile (file, proj) {
 function nonComments (obj) {
     const keys = Object.keys(obj);
     const newObj = {};
+    let i = 0;
 
-    for (const i in keys) {
+    for (i; i < keys.length; i++) {
         if (!COMMENT_KEY.test(keys[i])) {
             newObj[keys[i]] = obj[keys[i]];
         }
@@ -1960,8 +2008,8 @@ pbxProject.prototype.removeFromPbxGroupAndType = function (
     const group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group) {
         const groupChildren = group.children;
-
-        for (const i in groupChildren) {
+        let i;
+        for (i in groupChildren) {
             if (
                 pbxGroupChild(file).value === groupChildren[i].value &&
                 pbxGroupChild(file).comment === groupChildren[i].comment
@@ -1995,7 +2043,6 @@ pbxProject.prototype.getPBXVariantGroupByKey = function (key) {
 
 pbxProject.prototype.findPBXGroupKeyAndType = function (criteria, groupType) {
     const groups = this.hash.project.objects[groupType];
-
     let target;
 
     for (const key in groups) {
@@ -2074,7 +2121,7 @@ pbxProject.prototype.removeKnownRegion = function (name) {
         'knownRegions'
     ];
     if (regions) {
-        for (const i in regions) {
+        for (let i = 0; i < regions.length; i++) {
             if (regions[i] === name) {
                 regions.splice(i, 1);
                 break;
@@ -2138,9 +2185,8 @@ pbxProject.prototype.removeFile = function (path, group, opt) {
 };
 
 pbxProject.prototype.getBuildProperty = function (prop, build) {
-    const configs = this.pbxXCBuildConfigurationSection();
     let target;
-
+    const configs = this.pbxXCBuildConfigurationSection();
     for (const configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
             const config = configs[configName];
@@ -2192,11 +2238,8 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
     this.addToPbxSourcesBuildPhase(file);
 
     file.models = [];
-
     let currentVersionName;
-
     const modelFiles = fs.readdirSync(file.path);
-
     for (const index in modelFiles) {
         const modelFileName = modelFiles[index];
         const modelFilePath = path.join(filePath, modelFileName);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -110,8 +110,8 @@ pbxProject.prototype.addPluginFile = function(path, opt) {
 
     file.fileRef = this.generateUuid();
 
-    this.addToPbxFileReferenceSection(file);    // PBXFileReference
-    this.addToPluginsPbxGroup(file);            // PBXGroup
+    this.addToPbxFileReferenceSection(file); // -- PBXFileReference
+    this.addToPluginsPbxGroup(file); //         -- PBXGroup
 
     return file;
 }
@@ -120,8 +120,8 @@ pbxProject.prototype.removePluginFile = function(path, opt) {
     var file = new pbxFile(path, opt);
     correctForPluginsPath(file, this);
 
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
-    this.removeFromPluginsPbxGroup(file);            // PBXGroup
+    this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
+    this.removeFromPluginsPbxGroup(file); //         -- PBXGroup
 
     return file;
 }
@@ -136,8 +136,8 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
     file.uuid = this.generateUuid();
     file.path = file.basename;
 
-    this.addToPbxFileReferenceSection(file);
-    this.addToProductsPbxGroup(file);                // PBXGroup
+    this.addToPbxFileReferenceSection(file); // -- PBXFileReference
+    this.addToProductsPbxGroup(file); //        -- PBXGroup
 
     return file;
 }
@@ -145,7 +145,7 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
 pbxProject.prototype.removeProductFile = function(path, opt) {
     var file = new pbxFile(path, opt);
 
-    this.removeFromProductsPbxGroup(file);           // PBXGroup
+    this.removeFromProductsPbxGroup(file); // -- PBXGroup
 
     return file;
 }
@@ -171,8 +171,8 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
     file.target = opt ? opt.target : undefined;
     file.uuid = this.generateUuid();
 
-    this.addToPbxBuildFileSection(file);        // PBXBuildFile
-    this.addToPbxSourcesBuildPhase(file);       // PBXSourcesBuildPhase
+    this.addToPbxBuildFileSection(file); //  -- PBXBuildFile
+    this.addToPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
 
     return file;
 }
@@ -193,8 +193,8 @@ pbxProject.prototype.removeSourceFile = function (path, opt, group) {
         file = this.removePluginFile(path, opt);
     }
     file.target = opt ? opt.target : undefined;
-    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
-    this.removeFromPbxSourcesBuildPhase(file);       // PBXSourcesBuildPhase
+    this.removeFromPbxBuildFileSection(file); //  -- PBXBuildFile
+    this.removeFromPbxSourcesBuildPhase(file); // -- PBXSourcesBuildPhase
 
     return file;
 }
@@ -260,22 +260,22 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
     }
 
     if (!opt.variantGroup) {
-        this.addToPbxBuildFileSection(file);        // PBXBuildFile
-        this.addToPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
+        this.addToPbxBuildFileSection(file); //     -- PBXBuildFile
+        this.addToPbxResourcesBuildPhase(file); //  -- PBXResourcesBuildPhase
     }
 
     if (!opt.plugin) {
-        this.addToPbxFileReferenceSection(file);    // PBXFileReference
+        this.addToPbxFileReferenceSection(file); // -- PBXFileReference
         if (group) {
             if (this.getPBXGroupByKey(group)) {
-                this.addToPbxGroup(file, group);        //Group other than Resources (i.e. 'splash')
+                this.addToPbxGroup(file, group); // -- Group other than Resources (i.e. 'splash')
             }
             else if (this.getPBXVariantGroupByKey(group)) {
-                this.addToPbxVariantGroup(file, group);  // PBXVariantGroup
+                this.addToPbxVariantGroup(file, group); // -- PBXVariantGroup
             }
         }
         else {
-            this.addToResourcesPbxGroup(file);          // PBXGroup
+            this.addToResourcesPbxGroup(file); //   -- PBXGroup
         }
 
     }
@@ -296,28 +296,28 @@ pbxProject.prototype.removeResourceFile = function(path, opt, group) {
 
     correctForResourcesPath(file, this);
 
-    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromPbxBuildFileSection(file); //     -- PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
     if (group) {
         if (this.getPBXGroupByKey(group)) {
-            this.removeFromPbxGroup(file, group);        //Group other than Resources (i.e. 'splash')
+            this.removeFromPbxGroup(file, group); // -- Group other than Resources (i.e. 'splash')
         }
         else if (this.getPBXVariantGroupByKey(group)) {
-            this.removeFromPbxVariantGroup(file, group);  // PBXVariantGroup
+            this.removeFromPbxVariantGroup(file, group); // -- PBXVariantGroup
         }
     }
     else {
-        this.removeFromResourcesPbxGroup(file);          // PBXGroup
+        this.removeFromResourcesPbxGroup(file); //   -- PBXGroup
     }
-    this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
+    this.removeFromPbxResourcesBuildPhase(file); //  -- PBXResourcesBuildPhase
 
     return file;
 }
 
 pbxProject.prototype.addFramework = function(fpath, opt) {
     var customFramework = opt && opt.customFramework == true;
-    var link = !opt || (opt.link == undefined || opt.link);    //defaults to true if not specified
-    var embed = opt && opt.embed;                              //defaults to false if not specified
+    var link = !opt || (opt.link == undefined || opt.link); // -- defaults to true if not specified
+    var embed = opt && opt.embed; //                           -- defaults to false if not specified
 
     if (opt) {
       delete opt.embed;
@@ -331,12 +331,12 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
 
     if (this.hasFile(file.path)) return false;
 
-    this.addToPbxBuildFileSection(file);        // PBXBuildFile
-    this.addToPbxFileReferenceSection(file);    // PBXFileReference
-    this.addToFrameworksPbxGroup(file);         // PBXGroup
+    this.addToPbxBuildFileSection(file); //       -- PBXBuildFile
+    this.addToPbxFileReferenceSection(file); //   -- PBXFileReference
+    this.addToFrameworksPbxGroup(file); //        -- PBXGroup
 
     if (link) {
-      this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
+      this.addToPbxFrameworksBuildPhase(file); // -- PBXFrameworksBuildPhase
     }
 
     if (customFramework) {
@@ -349,10 +349,10 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
           embeddedFile.uuid = this.generateUuid();
           embeddedFile.fileRef = file.fileRef;
 
-          //keeping a separate PBXBuildFile entry for Embed Frameworks
-          this.addToPbxBuildFileSection(embeddedFile);        // PBXBuildFile
+          // keeping a separate PBXBuildFile entry for Embed Frameworks
+          this.addToPbxBuildFileSection(embeddedFile); //          -- PBXBuildFile
 
-          this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // PBXCopyFilesBuildPhase
+          this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // -- PBXCopyFilesBuildPhase
 
           return embeddedFile;
         }
@@ -371,10 +371,10 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
-    this.removeFromPbxBuildFileSection(file);          // PBXBuildFile
-    this.removeFromPbxFileReferenceSection(file);      // PBXFileReference
-    this.removeFromFrameworksPbxGroup(file);           // PBXGroup
-    this.removeFromPbxFrameworksBuildPhase(file);      // PBXFrameworksBuildPhase
+    this.removeFromPbxBuildFileSection(file); //     -- PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
+    this.removeFromFrameworksPbxGroup(file); //      -- PBXGroup
+    this.removeFromPbxFrameworksBuildPhase(file); // -- PBXFrameworksBuildPhase
 
     if (opt && opt.customFramework) {
         this.removeFromFrameworkSearchPaths(file);
@@ -386,8 +386,8 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
 
     embeddedFile.fileRef = file.fileRef;
 
-    this.removeFromPbxBuildFileSection(embeddedFile);          // PBXBuildFile
-    this.removeFromPbxEmbedFrameworksBuildPhase(embeddedFile); // PBXCopyFilesBuildPhase
+    this.removeFromPbxBuildFileSection(embeddedFile);          // -- PBXBuildFile
+    this.removeFromPbxEmbedFrameworksBuildPhase(embeddedFile); // -- PBXCopyFilesBuildPhase
 
     return file;
 }
@@ -404,9 +404,9 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
     file.fileRef = file.uuid = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
-    this.addToPbxBuildFileSection(file);        // PBXBuildFile
-    this.addToPbxFileReferenceSection(file);    // PBXFileReference
-    this.addToPbxCopyfilesBuildPhase(file);     // PBXCopyFilesBuildPhase
+    this.addToPbxBuildFileSection(file); //     -- PBXBuildFile
+    this.addToPbxFileReferenceSection(file); // -- PBXFileReference
+    this.addToPbxCopyfilesBuildPhase(file); //  -- PBXCopyFilesBuildPhase
 
     return file;
 }
@@ -424,9 +424,9 @@ pbxProject.prototype.removeCopyfile = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
-    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
-    this.removeFromPbxCopyfilesBuildPhase(file);    // PBXFrameworksBuildPhase
+    this.removeFromPbxBuildFileSection(file); //     -- PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
+    this.removeFromPbxCopyfilesBuildPhase(file); //  -- PBXFrameworksBuildPhase
 
     return file;
 }
@@ -459,12 +459,12 @@ pbxProject.prototype.addStaticLibrary = function(path, opt) {
 
     if (!opt.plugin) {
         file.fileRef = this.generateUuid();
-        this.addToPbxFileReferenceSection(file);    // PBXFileReference
+        this.addToPbxFileReferenceSection(file); // -- PBXFileReference
     }
 
-    this.addToPbxBuildFileSection(file);        // PBXBuildFile
-    this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
-    this.addToLibrarySearchPaths(file);        // make sure it gets built!
+    this.addToPbxBuildFileSection(file); //     -- PBXBuildFile
+    this.addToPbxFrameworksBuildPhase(file); // -- PBXFrameworksBuildPhase
+    this.addToLibrarySearchPaths(file); //      -- make sure it gets built!
 
     return file;
 }
@@ -529,8 +529,8 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
         var file = new pbxFile(filePath);
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
-        this.addToPbxFileReferenceSection(file);    // PBXFileReference
-        this.addToPbxBuildFileSection(file);        // PBXBuildFile
+        this.addToPbxFileReferenceSection(file); // -- PBXFileReference
+        this.addToPbxBuildFileSection(file); //     -- PBXBuildFile
         pbxGroup.children.push(pbxGroupChild(file));
     }
 
@@ -938,8 +938,8 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
 
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
-        this.addToPbxFileReferenceSection(file);    // PBXFileReference
-        this.addToPbxBuildFileSection(file);        // PBXBuildFile
+        this.addToPbxFileReferenceSection(file); //   -- PBXFileReference
+        this.addToPbxBuildFileSection(file); //       -- PBXBuildFile
         buildPhase.files.push(pbxBuildPhaseObj(file));
     }
 
@@ -1758,7 +1758,7 @@ pbxProject.prototype.addToPbxGroupType = function (file, groupKey, groupType) {
     var group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group && group.children !== undefined) {
         if (typeof file === 'string') {
-            //Group Key
+            // Group Key
             var childGroup = {
                 value:file,
             };
@@ -1772,7 +1772,7 @@ pbxProject.prototype.addToPbxGroupType = function (file, groupKey, groupType) {
             group.children.push(childGroup);
         }
         else {
-            //File Object
+            // File Object
             group.children.push(pbxGroupChild(file));
         }
     }
@@ -1912,8 +1912,8 @@ pbxProject.prototype.addLocalizationVariantGroup = function(name) {
         fileRef: groupKey,
         basename: name
     }
-    this.addToPbxBuildFileSection(localizationVariantGroup);        // PBXBuildFile
-    this.addToPbxResourcesBuildPhase(localizationVariantGroup);     //PBXResourcesBuildPhase
+    this.addToPbxBuildFileSection(localizationVariantGroup); //    -- PBXBuildFile
+    this.addToPbxResourcesBuildPhase(localizationVariantGroup); // -- PBXResourcesBuildPhase
 
     return localizationVariantGroup;
 };
@@ -1966,13 +1966,13 @@ pbxProject.prototype.addFile = function (path, group, opt) {
 
     file.fileRef = this.generateUuid();
 
-    this.addToPbxFileReferenceSection(file);    // PBXFileReference
+    this.addToPbxFileReferenceSection(file); // -- PBXFileReference
 
     if (this.getPBXGroupByKey(group)) {
-        this.addToPbxGroup(file, group);        // PBXGroup
+        this.addToPbxGroup(file, group); //     -- PBXGroup
     }
     else if (this.getPBXVariantGroupByKey(group)) {
-        this.addToPbxVariantGroup(file, group);            // PBXVariantGroup
+        this.addToPbxVariantGroup(file, group); // -- PBXVariantGroup
     }
 
     return file;
@@ -1981,13 +1981,13 @@ pbxProject.prototype.addFile = function (path, group, opt) {
 pbxProject.prototype.removeFile = function (path, group, opt) {
     var file = new pbxFile(path, opt);
 
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
 
     if (this.getPBXGroupByKey(group)) {
-        this.removeFromPbxGroup(file, group);            // PBXGroup
+        this.removeFromPbxGroup(file, group); //     -- PBXGroup
     }
     else if (this.getPBXVariantGroupByKey(group)) {
-        this.removeFromPbxVariantGroup(file, group);     // PBXVariantGroup
+        this.removeFromPbxVariantGroup(file, group); // -- PBXVariantGroup
     }
 
     return file;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -982,7 +982,7 @@ pbxProject.prototype.addBuildPhase = function (
     }
 
     if (!this.hash.project.objects[buildPhaseType]) {
-        this.hash.project.objects[buildPhaseType] = new Object();
+        this.hash.project.objects[buildPhaseType] = {};
     }
 
     if (!this.hash.project.objects[buildPhaseType][buildPhaseUuid]) {
@@ -1983,7 +1983,7 @@ pbxProject.prototype.pbxCreateGroupWithType = function (
     // add obj and commentObj to groups;
     var groups = this.hash.project.objects[groupType];
     if (!groups) {
-        groups = this.hash.project.objects[groupType] = new Object();
+        groups = this.hash.project.objects[groupType] = {};
     }
     groups[commendId] = name;
     groups[key] = model;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -872,13 +872,15 @@ pbxProject.prototype.addTargetDependency = function (
 
     var nativeTargets = this.pbxNativeTargetSection();
 
-    if (typeof nativeTargets[target] == 'undefined')
+    if (typeof nativeTargets[target] == 'undefined') {
         throw new Error('Invalid target: ' + target);
+    }
 
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTarget = dependencyTargets[index];
-        if (typeof nativeTargets[dependencyTarget] == 'undefined')
+        if (typeof nativeTargets[dependencyTarget] == 'undefined') {
             throw new Error('Invalid target: ' + dependencyTarget);
+        }
     }
 
     var pbxTargetDependency = 'PBXTargetDependency',
@@ -1175,8 +1177,9 @@ pbxProject.prototype.buildPhase = function (group, target) {
     if (!target) return undefined;
 
     var nativeTargets = this.pbxNativeTargetSection();
-    if (typeof nativeTargets[target] == 'undefined')
+    if (typeof nativeTargets[target] == 'undefined') {
         throw new Error('Invalid target: ' + target);
+    }
 
     var nativeTarget = nativeTargets[target];
     var buildPhases = nativeTarget.buildPhases;
@@ -1270,8 +1273,9 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         searchPaths = buildSettings[SEARCH_PATHS];
 
@@ -1297,8 +1301,9 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         if (
             !buildSettings['FRAMEWORK_SEARCH_PATHS'] ||
@@ -1325,8 +1330,9 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         searchPaths = buildSettings[SEARCH_PATHS];
 
@@ -1352,8 +1358,9 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         if (
             !buildSettings['LIBRARY_SEARCH_PATHS'] ||
@@ -1384,8 +1391,9 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         if (buildSettings[SEARCH_PATHS]) {
             var matches = buildSettings[SEARCH_PATHS].filter(function (p) {
@@ -1408,8 +1416,9 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         if (!buildSettings['HEADER_SEARCH_PATHS']) {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
@@ -1435,8 +1444,9 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
 
-        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
+        }
 
         if (
             !buildSettings[OTHER_LDFLAGS] ||
@@ -1799,8 +1809,9 @@ function correctForFrameworksPath (file, project) {
 function correctForPath (file, project, group) {
     var r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
-    if (project.pbxGroupByName(group).path)
+    if (project.pbxGroupByName(group).path) {
         file.path = file.path.replace(r_group_dir, '');
+    }
 
     return file;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -15,18 +15,18 @@
  under the License.
  */
 
-var util = require('util'),
-    f = util.format,
-    EventEmitter = require('events').EventEmitter,
-    path = require('path'),
-    uuid = require('uuid'),
-    fork = require('child_process').fork,
-    pbxWriter = require('./pbxWriter'),
-    pbxFile = require('./pbxFile'),
-    fs = require('fs'),
-    parser = require('./parser/pbxproj'),
-    plist = require('simple-plist'),
-    COMMENT_KEY = /_comment$/;
+const util = require('util');
+const f = util.format;
+const EventEmitter = require('events').EventEmitter;
+const path = require('path');
+const uuid = require('uuid');
+const fork = require('child_process').fork;
+const pbxWriter = require('./pbxWriter');
+const pbxFile = require('./pbxFile');
+const fs = require('fs');
+const parser = require('./parser/pbxproj');
+const plist = require('simple-plist');
+const COMMENT_KEY = /_comment$/;
 
 function pbxProject (filename) {
     if (!(this instanceof pbxProject)) return new pbxProject(filename);
@@ -37,7 +37,7 @@ function pbxProject (filename) {
 util.inherits(pbxProject, EventEmitter);
 
 pbxProject.prototype.parse = function (cb) {
-    var worker = fork(path.join(__dirname, '/parseJob.js'), [this.filepath]);
+    const worker = fork(path.join(__dirname, '/parseJob.js'), [this.filepath]);
 
     worker.on(
         'message',
@@ -60,7 +60,7 @@ pbxProject.prototype.parse = function (cb) {
 };
 
 pbxProject.prototype.parseSync = function () {
-    var file_contents = fs.readFileSync(this.filepath, 'utf-8');
+    const file_contents = fs.readFileSync(this.filepath, 'utf-8');
 
     this.hash = parser.parse(file_contents);
     return this;
@@ -72,9 +72,9 @@ pbxProject.prototype.writeSync = function (options) {
 };
 
 pbxProject.prototype.allUuids = function () {
-    var sections = this.hash.project.objects,
-        uuids = [],
-        section;
+    const sections = this.hash.project.objects;
+    let uuids = [];
+    let section;
 
     for (key in sections) {
         section = sections[key];
@@ -89,7 +89,7 @@ pbxProject.prototype.allUuids = function () {
 };
 
 pbxProject.prototype.generateUuid = function () {
-    var id = uuid
+    const id = uuid
         .v4()
         .replace(/-/g, '')
         .substr(0, 24)
@@ -103,7 +103,7 @@ pbxProject.prototype.generateUuid = function () {
 };
 
 pbxProject.prototype.addPluginFile = function (path, opt) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
 
     file.plugin = true; // durr
     correctForPluginsPath(file, this);
@@ -120,7 +120,7 @@ pbxProject.prototype.addPluginFile = function (path, opt) {
 };
 
 pbxProject.prototype.removePluginFile = function (path, opt) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
     correctForPluginsPath(file, this);
 
     this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
@@ -130,7 +130,7 @@ pbxProject.prototype.removePluginFile = function (path, opt) {
 };
 
 pbxProject.prototype.addProductFile = function (targetPath, opt) {
-    var file = new pbxFile(targetPath, opt);
+    const file = new pbxFile(targetPath, opt);
 
     file.includeInIndex = 0;
     file.fileRef = this.generateUuid();
@@ -146,7 +146,7 @@ pbxProject.prototype.addProductFile = function (targetPath, opt) {
 };
 
 pbxProject.prototype.removeProductFile = function (path, opt) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
 
     this.removeFromProductsPbxGroup(file); // -- PBXGroup
 
@@ -161,7 +161,7 @@ pbxProject.prototype.removeProductFile = function (path, opt) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.addSourceFile = function (path, opt, group) {
-    var file;
+    let file;
     if (group) {
         file = this.addFile(path, group, opt);
     } else {
@@ -187,7 +187,7 @@ pbxProject.prototype.addSourceFile = function (path, opt, group) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.removeSourceFile = function (path, opt, group) {
-    var file;
+    let file;
     if (group) {
         file = this.removeFile(path, group, opt);
     } else {
@@ -240,7 +240,7 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
 pbxProject.prototype.addResourceFile = function (path, opt, group) {
     opt = opt || {};
 
-    var file;
+    let file;
 
     if (opt.plugin) {
         file = this.addPluginFile(path, opt);
@@ -287,7 +287,7 @@ pbxProject.prototype.addResourceFile = function (path, opt, group) {
  * @returns {Object} file; see pbxFile
  */
 pbxProject.prototype.removeResourceFile = function (path, opt, group) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
 
     correctForResourcesPath(file, this);
@@ -309,15 +309,15 @@ pbxProject.prototype.removeResourceFile = function (path, opt, group) {
 };
 
 pbxProject.prototype.addFramework = function (fpath, opt) {
-    var customFramework = opt && opt.customFramework === true;
-    var link = !opt || (opt.link === undefined || opt.link); // -- defaults to true if not specified
-    var embed = opt && opt.embed; //                           -- defaults to false if not specified
+    const customFramework = opt && opt.customFramework === true;
+    const link = !opt || (opt.link === undefined || opt.link); // -- defaults to true if not specified
+    const embed = opt && opt.embed; //                           -- defaults to false if not specified
 
     if (opt) {
         delete opt.embed;
     }
 
-    var file = new pbxFile(fpath, opt);
+    const file = new pbxFile(fpath, opt);
 
     file.uuid = this.generateUuid();
     file.fileRef = this.generateUuid();
@@ -338,7 +338,7 @@ pbxProject.prototype.addFramework = function (fpath, opt) {
 
         if (embed) {
             opt.embed = embed;
-            var embeddedFile = new pbxFile(fpath, opt);
+            const embeddedFile = new pbxFile(fpath, opt);
 
             embeddedFile.uuid = this.generateUuid();
             embeddedFile.fileRef = file.fileRef;
@@ -356,13 +356,13 @@ pbxProject.prototype.addFramework = function (fpath, opt) {
 };
 
 pbxProject.prototype.removeFramework = function (fpath, opt) {
-    var embed = opt && opt.embed;
+    const embed = opt && opt.embed;
 
     if (opt) {
         delete opt.embed;
     }
 
-    var file = new pbxFile(fpath, opt);
+    const file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
     this.removeFromPbxBuildFileSection(file); //     -- PBXBuildFile
@@ -376,7 +376,7 @@ pbxProject.prototype.removeFramework = function (fpath, opt) {
 
     opt = opt || {};
     opt.embed = true;
-    var embeddedFile = new pbxFile(fpath, opt);
+    const embeddedFile = new pbxFile(fpath, opt);
 
     embeddedFile.fileRef = file.fileRef;
 
@@ -387,7 +387,7 @@ pbxProject.prototype.removeFramework = function (fpath, opt) {
 };
 
 pbxProject.prototype.addCopyfile = function (fpath, opt) {
-    var file = new pbxFile(fpath, opt);
+    let file = new pbxFile(fpath, opt);
 
     // catch duplicates
     if (this.hasFile(file.path)) {
@@ -413,7 +413,7 @@ pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function (target) {
 };
 
 pbxProject.prototype.addToPbxCopyfilesBuildPhase = function (file) {
-    var sources = this.buildPhaseObject(
+    const sources = this.buildPhaseObject(
         'PBXCopyFilesBuildPhase',
         'Copy Files',
         file.target
@@ -422,7 +422,7 @@ pbxProject.prototype.addToPbxCopyfilesBuildPhase = function (file) {
 };
 
 pbxProject.prototype.removeCopyfile = function (fpath, opt) {
-    var file = new pbxFile(fpath, opt);
+    const file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
     this.removeFromPbxBuildFileSection(file); //     -- PBXBuildFile
@@ -433,7 +433,7 @@ pbxProject.prototype.removeCopyfile = function (fpath, opt) {
 };
 
 pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
-    var sources = this.pbxCopyfilesBuildPhaseObj(file.target);
+    const sources = this.pbxCopyfilesBuildPhaseObj(file.target);
     for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
@@ -445,7 +445,7 @@ pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function (file) {
 pbxProject.prototype.addStaticLibrary = function (path, opt) {
     opt = opt || {};
 
-    var file;
+    let file;
 
     if (opt.plugin) {
         file = this.addPluginFile(path, opt);
@@ -472,14 +472,14 @@ pbxProject.prototype.addStaticLibrary = function (path, opt) {
 
 // helper addition functions
 pbxProject.prototype.addToPbxBuildFileSection = function (file) {
-    var commentKey = f('%s_comment', file.uuid);
+    const commentKey = f('%s_comment', file.uuid);
 
     this.pbxBuildFileSection()[file.uuid] = pbxBuildFileObj(file);
     this.pbxBuildFileSection()[commentKey] = pbxBuildFileComment(file);
 };
 
 pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
-    var uuid;
+    let uuid;
 
     for (uuid in this.pbxBuildFileSection()) {
         if (
@@ -488,7 +488,7 @@ pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
 
-            var commentKey = f('%s_comment', uuid);
+            const commentKey = f('%s_comment', uuid);
             delete this.pbxBuildFileSection()[commentKey];
         }
     }
@@ -500,25 +500,25 @@ pbxProject.prototype.addPbxGroup = function (
     path,
     sourceTree
 ) {
-    var groups = this.hash.project.objects['PBXGroup'],
-        pbxGroupUuid = this.generateUuid(),
-        commentKey = f('%s_comment', pbxGroupUuid),
-        pbxGroup = {
-            isa: 'PBXGroup',
-            children: [],
-            name: name,
-            path: path,
-            sourceTree: sourceTree ? sourceTree : '"<group>"'
-        },
-        fileReferenceSection = this.pbxFileReferenceSection(),
-        filePathToReference = {};
+    const groups = this.hash.project.objects['PBXGroup'];
+    const pbxGroupUuid = this.generateUuid();
+    const commentKey = f('%s_comment', pbxGroupUuid);
+    const pbxGroup = {
+        isa: 'PBXGroup',
+        children: [],
+        name: name,
+        path: path,
+        sourceTree: sourceTree ? sourceTree : '"<group>"'
+    };
+    const fileReferenceSection = this.pbxFileReferenceSection();
+    const filePathToReference = {};
 
-    for (var key in fileReferenceSection) {
+    for (const key in fileReferenceSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        var fileReferenceKey = key.split(COMMENT_KEY)[0],
-            fileReference = fileReferenceSection[fileReferenceKey];
+        const fileReferenceKey = key.split(COMMENT_KEY)[0];
+        const fileReference = fileReferenceSection[fileReferenceKey];
 
         filePathToReference[fileReference.path] = {
             fileRef: fileReferenceKey,
@@ -526,9 +526,9 @@ pbxProject.prototype.addPbxGroup = function (
         };
     }
 
-    for (var index = 0; index < filePathsArray.length; index++) {
-        var filePath = filePathsArray[index],
-            filePathQuoted = '"' + filePath + '"';
+    for (let index = 0; index < filePathsArray.length; index++) {
+        const filePath = filePathsArray[index];
+        const filePathQuoted = '"' + filePath + '"';
         if (filePathToReference[filePath]) {
             pbxGroup.children.push(
                 pbxGroupChild(filePathToReference[filePath])
@@ -541,7 +541,7 @@ pbxProject.prototype.addPbxGroup = function (
             continue;
         }
 
-        var file = new pbxFile(filePath);
+        const file = new pbxFile(filePath);
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file); // -- PBXFileReference
@@ -558,9 +558,9 @@ pbxProject.prototype.addPbxGroup = function (
 };
 
 pbxProject.prototype.removePbxGroup = function (groupName) {
-    var section = this.hash.project.objects['PBXGroup'],
-        key,
-        itemKey;
+    const section = this.hash.project.objects['PBXGroup'];
+    let key;
+    let itemKey;
 
     for (key in section) {
         // only look for comments
@@ -574,7 +574,7 @@ pbxProject.prototype.removePbxGroup = function (groupName) {
 };
 
 pbxProject.prototype.addToPbxProjectSection = function (target) {
-    var newTarget = {
+    const newTarget = {
         value: target.uuid,
         comment: pbxNativeTargetComment(target.pbxNativeTarget)
     };
@@ -585,14 +585,14 @@ pbxProject.prototype.addToPbxProjectSection = function (target) {
 };
 
 pbxProject.prototype.addToPbxNativeTargetSection = function (target) {
-    var commentKey = f('%s_comment', target.uuid);
+    const commentKey = f('%s_comment', target.uuid);
 
     this.pbxNativeTargetSection()[target.uuid] = target.pbxNativeTarget;
     this.pbxNativeTargetSection()[commentKey] = target.pbxNativeTarget.name;
 };
 
 pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
-    var commentKey = f('%s_comment', file.fileRef);
+    const commentKey = f('%s_comment', file.fileRef);
 
     this.pbxFileReferenceSection()[file.fileRef] = pbxFileReferenceObj(file);
     this.pbxFileReferenceSection()[commentKey] = pbxFileReferenceComment(
@@ -601,8 +601,8 @@ pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
 };
 
 pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
-    var i;
-    var refObj = pbxFileReferenceObj(file);
+    let i;
+    const refObj = pbxFileReferenceObj(file);
     for (i in this.pbxFileReferenceSection()) {
         if (
             this.pbxFileReferenceSection()[i].name === refObj.name ||
@@ -616,7 +616,7 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
             break;
         }
     }
-    var commentKey = f('%s_comment', file.fileRef);
+    const commentKey = f('%s_comment', file.fileRef);
     if (this.pbxFileReferenceSection()[commentKey] !== undefined) {
         delete this.pbxFileReferenceSection()[commentKey];
     }
@@ -631,7 +631,7 @@ pbxProject.prototype.addToXcVersionGroupSection = function (file) {
         );
     }
 
-    var commentKey = f('%s_comment', file.fileRef);
+    const commentKey = f('%s_comment', file.fileRef);
 
     if (!this.xcVersionGroupSection()[file.fileRef]) {
         this.xcVersionGroupSection()[file.fileRef] = {
@@ -650,7 +650,7 @@ pbxProject.prototype.addToXcVersionGroupSection = function (file) {
 };
 
 pbxProject.prototype.addToPluginsPbxGroup = function (file) {
-    var pluginsGroup = this.pbxGroupByName('Plugins');
+    const pluginsGroup = this.pbxGroupByName('Plugins');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Plugins');
     } else {
@@ -662,8 +662,8 @@ pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
     if (!this.pbxGroupByName('Plugins')) {
         return null;
     }
-    var pluginsGroupChildren = this.pbxGroupByName('Plugins').children,
-        i;
+    const pluginsGroupChildren = this.pbxGroupByName('Plugins').children;
+    let i;
     for (i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
@@ -676,7 +676,7 @@ pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
 };
 
 pbxProject.prototype.addToResourcesPbxGroup = function (file) {
-    var pluginsGroup = this.pbxGroupByName('Resources');
+    const pluginsGroup = this.pbxGroupByName('Resources');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Resources');
     } else {
@@ -688,8 +688,8 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
     if (!this.pbxGroupByName('Resources')) {
         return null;
     }
-    var pluginsGroupChildren = this.pbxGroupByName('Resources').children,
-        i;
+    const pluginsGroupChildren = this.pbxGroupByName('Resources').children;
+    let i;
     for (i in pluginsGroupChildren) {
         if (
             pbxGroupChild(file).value === pluginsGroupChildren[i].value &&
@@ -702,7 +702,7 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
 };
 
 pbxProject.prototype.addToFrameworksPbxGroup = function (file) {
-    var pluginsGroup = this.pbxGroupByName('Frameworks');
+    const pluginsGroup = this.pbxGroupByName('Frameworks');
     if (!pluginsGroup) {
         this.addPbxGroup([file.path], 'Frameworks');
     } else {
@@ -714,7 +714,7 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
     if (!this.pbxGroupByName('Frameworks')) {
         return null;
     }
-    var pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
+    const pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
 
     for (i in pluginsGroupChildren) {
         if (
@@ -728,16 +728,16 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
 };
 
 pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
-    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
+    const sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
     if (sources) {
         sources.files.push(pbxBuildPhaseObj(file));
     }
 };
 
 pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
-    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
+    const sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
     if (sources) {
-        var files = [];
+        const files = [];
         for (i in sources.files) {
             if (sources.files[i].comment !== longComment(file)) {
                 files.push(sources.files[i]);
@@ -748,7 +748,7 @@ pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
 };
 
 pbxProject.prototype.addToProductsPbxGroup = function (file) {
-    var productsGroup = this.pbxGroupByName('Products');
+    const productsGroup = this.pbxGroupByName('Products');
     if (!productsGroup) {
         this.addPbxGroup([file.path], 'Products');
     } else {
@@ -760,8 +760,8 @@ pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
     if (!this.pbxGroupByName('Products')) {
         return null;
     }
-    var productsGroupChildren = this.pbxGroupByName('Products').children,
-        i;
+    const productsGroupChildren = this.pbxGroupByName('Products').children;
+    let i;
     for (i in productsGroupChildren) {
         if (
             pbxGroupChild(file).value === productsGroupChildren[i].value &&
@@ -774,13 +774,13 @@ pbxProject.prototype.removeFromProductsPbxGroup = function (file) {
 };
 
 pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
-    var sources = this.pbxSourcesBuildPhaseObj(file.target);
+    const sources = this.pbxSourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 };
 
 pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
-    var sources = this.pbxSourcesBuildPhaseObj(file.target),
-        i;
+    const sources = this.pbxSourcesBuildPhaseObj(file.target);
+    let i;
     for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
@@ -790,13 +790,13 @@ pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
 };
 
 pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
-    var sources = this.pbxResourcesBuildPhaseObj(file.target);
+    const sources = this.pbxResourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 };
 
 pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
-    var sources = this.pbxResourcesBuildPhaseObj(file.target),
-        i;
+    const sources = this.pbxResourcesBuildPhaseObj(file.target);
+    let i;
 
     for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
@@ -807,12 +807,12 @@ pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
 };
 
 pbxProject.prototype.addToPbxFrameworksBuildPhase = function (file) {
-    var sources = this.pbxFrameworksBuildPhaseObj(file.target);
+    const sources = this.pbxFrameworksBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 };
 
 pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
-    var sources = this.pbxFrameworksBuildPhaseObj(file.target);
+    const sources = this.pbxFrameworksBuildPhaseObj(file.target);
     for (i in sources.files) {
         if (sources.files[i].comment === longComment(file)) {
             sources.files.splice(i, 1);
@@ -826,21 +826,21 @@ pbxProject.prototype.addXCConfigurationList = function (
     defaultConfigurationName,
     comment
 ) {
-    var pbxBuildConfigurationSection = this.pbxXCBuildConfigurationSection(),
-        pbxXCConfigurationListSection = this.pbxXCConfigurationList(),
-        xcConfigurationListUuid = this.generateUuid(),
-        commentKey = f('%s_comment', xcConfigurationListUuid),
-        xcConfigurationList = {
-            isa: 'XCConfigurationList',
-            buildConfigurations: [],
-            defaultConfigurationIsVisible: 0,
-            defaultConfigurationName: defaultConfigurationName
-        };
+    const pbxBuildConfigurationSection = this.pbxXCBuildConfigurationSection();
+    const pbxXCConfigurationListSection = this.pbxXCConfigurationList();
+    const xcConfigurationListUuid = this.generateUuid();
+    const commentKey = f('%s_comment', xcConfigurationListUuid);
+    const xcConfigurationList = {
+        isa: 'XCConfigurationList',
+        buildConfigurations: [],
+        defaultConfigurationIsVisible: 0,
+        defaultConfigurationName: defaultConfigurationName
+    };
 
-    for (var index = 0; index < configurationObjectsArray.length; index++) {
-        var configuration = configurationObjectsArray[index],
-            configurationUuid = this.generateUuid(),
-            configurationCommentKey = f('%s_comment', configurationUuid);
+    for (let index = 0; index < configurationObjectsArray.length; index++) {
+        const configuration = configurationObjectsArray[index];
+        const configurationUuid = this.generateUuid();
+        const configurationCommentKey = f('%s_comment', configurationUuid);
 
         pbxBuildConfigurationSection[configurationUuid] = configuration;
         pbxBuildConfigurationSection[configurationCommentKey] =
@@ -870,58 +870,57 @@ pbxProject.prototype.addTargetDependency = function (
 ) {
     if (!target) return undefined;
 
-    var nativeTargets = this.pbxNativeTargetSection();
+    const nativeTargets = this.pbxNativeTargetSection();
 
     if (typeof nativeTargets[target] === 'undefined') {
         throw new Error('Invalid target: ' + target);
     }
 
-    for (var index = 0; index < dependencyTargets.length; index++) {
-        var dependencyTarget = dependencyTargets[index];
+    dependencyTargets.forEach(dependencyTarget => {
         if (typeof nativeTargets[dependencyTarget] === 'undefined') {
             throw new Error('Invalid target: ' + dependencyTarget);
         }
-    }
+    });
 
-    var pbxTargetDependency = 'PBXTargetDependency',
-        pbxContainerItemProxy = 'PBXContainerItemProxy',
-        pbxTargetDependencySection = this.hash.project.objects[
-            pbxTargetDependency
-        ],
-        pbxContainerItemProxySection = this.hash.project.objects[
-            pbxContainerItemProxy
-        ];
+    const pbxTargetDependency = 'PBXTargetDependency';
+    const pbxContainerItemProxy = 'PBXContainerItemProxy';
+    const pbxTargetDependencySection = this.hash.project.objects[
+        pbxTargetDependency
+    ];
+    const pbxContainerItemProxySection = this.hash.project.objects[
+        pbxContainerItemProxy
+    ];
 
-    for (var index = 0; index < dependencyTargets.length; index++) {
-        var dependencyTargetUuid = dependencyTargets[index],
-            dependencyTargetCommentKey = f(
-                '%s_comment',
-                dependencyTargetUuid
-            ),
-            targetDependencyUuid = this.generateUuid(),
-            targetDependencyCommentKey = f(
-                '%s_comment',
-                targetDependencyUuid
-            ),
-            itemProxyUuid = this.generateUuid(),
-            itemProxyCommentKey = f('%s_comment', itemProxyUuid),
-            itemProxy = {
-                isa: pbxContainerItemProxy,
-                containerPortal: this.hash.project['rootObject'],
-                containerPortal_comment: this.hash.project[
-                    'rootObject_comment'
-                ],
-                proxyType: 1,
-                remoteGlobalIDString: dependencyTargetUuid,
-                remoteInfo: nativeTargets[dependencyTargetUuid].name
-            },
-            targetDependency = {
-                isa: pbxTargetDependency,
-                target: dependencyTargetUuid,
-                target_comment: nativeTargets[dependencyTargetCommentKey],
-                targetProxy: itemProxyUuid,
-                targetProxy_comment: pbxContainerItemProxy
-            };
+    for (let index = 0; index < dependencyTargets.length; index++) {
+        const dependencyTargetUuid = dependencyTargets[index];
+        const dependencyTargetCommentKey = f(
+            '%s_comment',
+            dependencyTargetUuid
+        );
+        const targetDependencyUuid = this.generateUuid();
+        const targetDependencyCommentKey = f(
+            '%s_comment',
+            targetDependencyUuid
+        );
+        const itemProxyUuid = this.generateUuid();
+        const itemProxyCommentKey = f('%s_comment', itemProxyUuid);
+        const itemProxy = {
+            isa: pbxContainerItemProxy,
+            containerPortal: this.hash.project['rootObject'],
+            containerPortal_comment: this.hash.project[
+                'rootObject_comment'
+            ],
+            proxyType: 1,
+            remoteGlobalIDString: dependencyTargetUuid,
+            remoteInfo: nativeTargets[dependencyTargetUuid].name
+        };
+        const targetDependency = {
+            isa: pbxTargetDependency,
+            target: dependencyTargetUuid,
+            target_comment: nativeTargets[dependencyTargetCommentKey],
+            targetProxy: itemProxyUuid,
+            targetProxy_comment: pbxContainerItemProxy
+        };
 
         if (pbxContainerItemProxySection && pbxTargetDependencySection) {
             pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
@@ -952,19 +951,19 @@ pbxProject.prototype.addBuildPhase = function (
     optionsOrFolderType,
     subfolderPath
 ) {
-    var buildPhaseSection,
-        fileReferenceSection = this.pbxFileReferenceSection(),
-        buildFileSection = this.pbxBuildFileSection(),
-        buildPhaseUuid = this.generateUuid(),
-        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
-        commentKey = f('%s_comment', buildPhaseUuid),
-        buildPhase = {
-            isa: buildPhaseType,
-            buildActionMask: 2147483647,
-            files: [],
-            runOnlyForDeploymentPostprocessing: 0
-        },
-        filePathToBuildFile = {};
+    let buildPhaseSection;
+    const fileReferenceSection = this.pbxFileReferenceSection();
+    const buildFileSection = this.pbxBuildFileSection();
+    const buildPhaseUuid = this.generateUuid();
+    const buildPhaseTargetUuid = target || this.getFirstTarget().uuid;
+    const commentKey = f('%s_comment', buildPhaseUuid);
+    let buildPhase = {
+        isa: buildPhaseType,
+        buildActionMask: 2147483647,
+        files: [],
+        runOnlyForDeploymentPostprocessing: 0
+    };
+    const filePathToBuildFile = {};
 
     if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
         buildPhase = pbxCopyFilesBuildPhaseObj(
@@ -1005,17 +1004,17 @@ pbxProject.prototype.addBuildPhase = function (
         });
     }
 
-    for (var key in buildFileSection) {
+    for (const key in buildFileSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        var buildFileKey = key.split(COMMENT_KEY)[0],
-            buildFile = buildFileSection[buildFileKey];
+        const buildFileKey = key.split(COMMENT_KEY)[0];
+        const buildFile = buildFileSection[buildFileKey];
         fileReference = fileReferenceSection[buildFile.fileRef];
 
         if (!fileReference) continue;
 
-        var pbxFileObj = new pbxFile(fileReference.path);
+        const pbxFileObj = new pbxFile(fileReference.path);
 
         filePathToBuildFile[fileReference.path] = {
             uuid: buildFileKey,
@@ -1024,10 +1023,10 @@ pbxProject.prototype.addBuildPhase = function (
         };
     }
 
-    for (var index = 0; index < filePathsArray.length; index++) {
-        var filePath = filePathsArray[index],
-            filePathQuoted = '"' + filePath + '"',
-            file = new pbxFile(filePath);
+    for (let index = 0; index < filePathsArray.length; index++) {
+        const filePath = filePathsArray[index];
+        const filePathQuoted = '"' + filePath + '"';
+        const file = new pbxFile(filePath);
 
         if (filePathToBuildFile[filePath]) {
             buildPhase.files.push(
@@ -1089,9 +1088,9 @@ pbxProject.prototype.pbxXCConfigurationList = function () {
 };
 
 pbxProject.prototype.pbxGroupByName = function (name) {
-    var groups = this.hash.project.objects['PBXGroup'],
-        key,
-        groupKey;
+    const groups = this.hash.project.objects['PBXGroup'];
+    let key;
+    let groupKey;
 
     for (key in groups) {
         // only look for comments
@@ -1111,13 +1110,13 @@ pbxProject.prototype.pbxTargetByName = function (name) {
 };
 
 pbxProject.prototype.findTargetKey = function (name) {
-    var targets = this.hash.project.objects['PBXNativeTarget'];
+    const targets = this.hash.project.objects['PBXNativeTarget'];
 
-    for (var key in targets) {
+    for (const key in targets) {
         // only look for comments
         if (COMMENT_KEY.test(key)) continue;
 
-        var target = targets[key];
+        const target = targets[key];
         if (target.name === name) {
             return key;
         }
@@ -1127,9 +1126,9 @@ pbxProject.prototype.findTargetKey = function (name) {
 };
 
 pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
-    var section = this.hash.project.objects[pbxSectionName],
-        key,
-        itemKey;
+    const section = this.hash.project.objects[pbxSectionName];
+    let key;
+    let itemKey;
 
     for (key in section) {
         // only look for comments
@@ -1176,15 +1175,15 @@ pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
 pbxProject.prototype.buildPhase = function (group, target) {
     if (!target) return undefined;
 
-    var nativeTargets = this.pbxNativeTargetSection();
+    const nativeTargets = this.pbxNativeTargetSection();
     if (typeof nativeTargets[target] === 'undefined') {
         throw new Error('Invalid target: ' + target);
     }
 
-    var nativeTarget = nativeTargets[target];
-    var buildPhases = nativeTarget.buildPhases;
-    for (var i in buildPhases) {
-        var buildPhase = buildPhases[i];
+    const nativeTarget = nativeTargets[target];
+    const buildPhases = nativeTarget.buildPhases;
+    for (const i in buildPhases) {
+        const buildPhase = buildPhases[i];
         if (buildPhase.comment === group) {
             return buildPhase.value + '_comment';
         }
@@ -1192,11 +1191,11 @@ pbxProject.prototype.buildPhase = function (group, target) {
 };
 
 pbxProject.prototype.buildPhaseObject = function (name, group, target) {
-    var section = this.hash.project.objects[name],
-        obj,
-        sectionKey,
-        key;
-    var buildPhase = this.buildPhase(group, target);
+    const section = this.hash.project.objects[name];
+    let obj;
+    let sectionKey;
+    let key;
+    const buildPhase = this.buildPhase(group, target);
 
     for (key in section) {
         // only look for comments
@@ -1213,9 +1212,9 @@ pbxProject.prototype.buildPhaseObject = function (name, group, target) {
 };
 
 pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        key,
-        configuration;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let key;
+    let configuration;
 
     for (key in configurations) {
         configuration = configurations[key];
@@ -1226,9 +1225,9 @@ pbxProject.prototype.addBuildProperty = function (prop, value, build_name) {
 };
 
 pbxProject.prototype.removeBuildProperty = function (prop, build_name) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        key,
-        configuration;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let key;
+    let configuration;
 
     for (key in configurations) {
         configuration = configurations[key];
@@ -1248,10 +1247,10 @@ pbxProject.prototype.removeBuildProperty = function (prop, build_name) {
  * @param build {String} Release or Debug
  */
 pbxProject.prototype.updateBuildProperty = function (prop, value, build) {
-    var configs = this.pbxXCBuildConfigurationSection();
-    for (var configName in configs) {
+    const configs = this.pbxXCBuildConfigurationSection();
+    for (const configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
-            var config = configs[configName];
+            const config = configs[configName];
             if ((build && config.name === build) || !build) {
                 config.buildSettings[prop] = value;
             }
@@ -1264,13 +1263,13 @@ pbxProject.prototype.updateProductName = function (name) {
 };
 
 pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS',
-        config,
-        buildSettings,
-        searchPaths;
-    var new_path = searchPathForFile(file, this);
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    const SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS';
+    let config;
+    let buildSettings;
+    let searchPaths;
+    const new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1282,11 +1281,11 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
-            var matches = searchPaths.filter(function (p) {
+            const matches = searchPaths.filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
             matches.forEach(function (m) {
-                var idx = searchPaths.indexOf(m);
+                const idx = searchPaths.indexOf(m);
                 searchPaths.splice(idx, 1);
             });
         }
@@ -1294,11 +1293,11 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
 };
 
 pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        config,
-        buildSettings,
-        searchPaths;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1321,13 +1320,13 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
 };
 
 pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS',
-        config,
-        buildSettings,
-        searchPaths;
-    var new_path = searchPathForFile(file, this);
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    const SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS';
+    let config;
+    let buildSettings;
+    let searchPaths;
+    const new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1339,11 +1338,11 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths && Array.isArray(searchPaths)) {
-            var matches = searchPaths.filter(function (p) {
+            const matches = searchPaths.filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
             matches.forEach(function (m) {
-                var idx = searchPaths.indexOf(m);
+                const idx = searchPaths.indexOf(m);
                 searchPaths.splice(idx, 1);
             });
         }
@@ -1351,11 +1350,11 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
 };
 
 pbxProject.prototype.addToLibrarySearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        config,
-        buildSettings,
-        searchPaths;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1382,13 +1381,13 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
 };
 
 pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
-        config,
-        buildSettings,
-        searchPaths;
-    var new_path = searchPathForFile(file, this);
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    const SEARCH_PATHS = 'HEADER_SEARCH_PATHS';
+    let config;
+    let buildSettings;
+    let searchPaths;
+    const new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1398,22 +1397,22 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
         }
 
         if (buildSettings[SEARCH_PATHS]) {
-            var matches = buildSettings[SEARCH_PATHS].filter(function (p) {
+            const matches = buildSettings[SEARCH_PATHS].filter(function (p) {
                 return p.indexOf(new_path) > -1;
             });
             matches.forEach(function (m) {
-                var idx = buildSettings[SEARCH_PATHS].indexOf(m);
+                const idx = buildSettings[SEARCH_PATHS].indexOf(m);
                 buildSettings[SEARCH_PATHS].splice(idx, 1);
             });
         }
     }
 };
 pbxProject.prototype.addToHeaderSearchPaths = function (file) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        config,
-        buildSettings,
-        searchPaths;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    let config;
+    let buildSettings;
+    let searchPaths;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1437,11 +1436,11 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
 };
 
 pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        INHERITED = '"$(inherited)"',
-        OTHER_LDFLAGS = 'OTHER_LDFLAGS',
-        config,
-        buildSettings;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const INHERITED = '"$(inherited)"';
+    const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
+    let config;
+    let buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1462,10 +1461,10 @@ pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
 };
 
 pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        OTHER_LDFLAGS = 'OTHER_LDFLAGS',
-        config,
-        buildSettings;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    const OTHER_LDFLAGS = 'OTHER_LDFLAGS';
+    let config;
+    let buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1475,11 +1474,11 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
         }
 
         if (buildSettings[OTHER_LDFLAGS]) {
-            var matches = buildSettings[OTHER_LDFLAGS].filter(function (p) {
+            const matches = buildSettings[OTHER_LDFLAGS].filter(function (p) {
                 return p.indexOf(flag) > -1;
             });
             matches.forEach(function (m) {
-                var idx = buildSettings[OTHER_LDFLAGS].indexOf(m);
+                const idx = buildSettings[OTHER_LDFLAGS].indexOf(m);
                 buildSettings[OTHER_LDFLAGS].splice(idx, 1);
             });
         }
@@ -1487,9 +1486,9 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
 };
 
 pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config,
-        buildSettings;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1499,9 +1498,9 @@ pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
 };
 
 pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config,
-        buildSettings;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let buildSettings;
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -1514,9 +1513,9 @@ pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
 
 // a JS getter. hmmm
 pbxProject.prototype.__defineGetter__('productName', function () {
-    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
-        config,
-        productName;
+    const configurations = nonComments(this.pbxXCBuildConfigurationSection());
+    let config;
+    let productName;
 
     for (config in configurations) {
         productName = configurations[config].buildSettings['PRODUCT_NAME'];
@@ -1529,9 +1528,9 @@ pbxProject.prototype.__defineGetter__('productName', function () {
 
 // check if file is present
 pbxProject.prototype.hasFile = function (filePath) {
-    var files = nonComments(this.pbxFileReferenceSection()),
-        file,
-        id;
+    const files = nonComments(this.pbxFileReferenceSection());
+    let file;
+    let id;
     for (id in files) {
         file = files[id];
         if (file.path === filePath || file.path === '"' + filePath + '"') {
@@ -1544,10 +1543,10 @@ pbxProject.prototype.hasFile = function (filePath) {
 
 pbxProject.prototype.addTarget = function (name, type, subfolder) {
     // Setup uuid and name of new target
-    var targetUuid = this.generateUuid(),
-        targetType = type,
-        targetSubfolder = subfolder || name,
-        targetName = name.trim();
+    const targetUuid = this.generateUuid();
+    const targetType = type;
+    const targetSubfolder = subfolder || name;
+    const targetName = name.trim();
 
     // Check type against list of allowed target types
     if (!targetName) {
@@ -1565,7 +1564,7 @@ pbxProject.prototype.addTarget = function (name, type, subfolder) {
     }
 
     // Build Configuration: Create
-    var buildConfigurationsList = [
+    const buildConfigurationsList = [
         {
             name: 'Debug',
             isa: 'XCBuildConfiguration',
@@ -1602,28 +1601,28 @@ pbxProject.prototype.addTarget = function (name, type, subfolder) {
     ];
 
     // Build Configuration: Add
-    var buildConfigurations = this.addXCConfigurationList(
+    const buildConfigurations = this.addXCConfigurationList(
         buildConfigurationsList,
         'Release',
         'Build configuration list for PBXNativeTarget "' + targetName + '"'
     );
 
     // Product: Create
-    var productName = targetName,
-        productType = producttypeForTargettype(targetType),
-        productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, {
-            group: 'Copy Files',
-            target: targetUuid,
-            explicitFileType: productFileType
-        }),
-        productFileName = productFile.basename;
+    const productName = targetName;
+    const productType = producttypeForTargettype(targetType);
+    const productFileType = filetypeForProducttype(productType);
+    const productFile = this.addProductFile(productName, {
+        group: 'Copy Files',
+        target: targetUuid,
+        explicitFileType: productFileType
+    });
+    const productFileName = productFile.basename;
 
     // Product: Add to build file list
     this.addToPbxBuildFileSection(productFile);
 
     // Target: Create
-    var target = {
+    const target = {
         uuid: targetUuid,
         pbxNativeTarget: {
             isa: 'PBXNativeTarget',
@@ -1670,8 +1669,8 @@ pbxProject.prototype.addTarget = function (name, type, subfolder) {
 
 // helper recursive prop search+replace
 function propReplace (obj, prop, value) {
-    var o = {};
-    for (var p in obj) {
+    const o = {};
+    for (const p in obj) {
         if (o.hasOwnProperty.call(obj, p)) {
             if (typeof obj[p] === 'object' && !Array.isArray(obj[p])) {
                 propReplace(obj[p], prop, value);
@@ -1684,7 +1683,7 @@ function propReplace (obj, prop, value) {
 
 // helper object creation functions
 function pbxBuildFileObj (file) {
-    var obj = Object.create(null);
+    const obj = Object.create(null);
 
     obj.isa = 'PBXBuildFile';
     obj.fileRef = file.fileRef;
@@ -1695,7 +1694,7 @@ function pbxBuildFileObj (file) {
 }
 
 function pbxFileReferenceObj (file) {
-    var fileObject = {
+    const fileObject = {
         isa: 'PBXFileReference',
         name: '"' + file.basename + '"',
         path: '"' + file.path.replace(/\\/g, '/') + '"',
@@ -1710,7 +1709,7 @@ function pbxFileReferenceObj (file) {
 }
 
 function pbxGroupChild (file) {
-    var obj = Object.create(null);
+    const obj = Object.create(null);
 
     obj.value = file.fileRef;
     obj.comment = file.basename;
@@ -1719,7 +1718,7 @@ function pbxGroupChild (file) {
 }
 
 function pbxBuildPhaseObj (file) {
-    var obj = Object.create(null);
+    const obj = Object.create(null);
 
     obj.value = file.uuid;
     obj.comment = longComment(file);
@@ -1734,7 +1733,7 @@ function pbxCopyFilesBuildPhaseObj (
     phaseName
 ) {
     // Add additional properties for 'CopyFiles' build phase
-    var DESTINATION_BY_TARGETTYPE = {
+    const DESTINATION_BY_TARGETTYPE = {
         application: 'wrapper',
         app_extension: 'plugins',
         bundle: 'wrapper',
@@ -1747,7 +1746,7 @@ function pbxCopyFilesBuildPhaseObj (
         watch_app: 'wrapper',
         watch_extension: 'plugins'
     };
-    var SUBFOLDERSPEC_BY_DESTINATION = {
+    const SUBFOLDERSPEC_BY_DESTINATION = {
         absolute_path: 0,
         executables: 6,
         frameworks: 10,
@@ -1809,7 +1808,7 @@ function correctForFrameworksPath (file, project) {
 }
 
 function correctForPath (file, project, group) {
-    var r_group_dir = new RegExp('^' + group + '[\\\\/]');
+    const r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
     if (project.pbxGroupByName(group).path) {
         file.path = file.path.replace(r_group_dir, '');
@@ -1819,9 +1818,9 @@ function correctForPath (file, project, group) {
 }
 
 function searchPathForFile (file, proj) {
-    var plugins = proj.pbxGroupByName('Plugins'),
-        pluginsPath = plugins ? plugins.path : null,
-        fileDir = path.dirname(file.path);
+    const plugins = proj.pbxGroupByName('Plugins');
+    const pluginsPath = plugins ? plugins.path : null;
+    let fileDir = path.dirname(file.path);
 
     if (fileDir === '.') {
         fileDir = '';
@@ -1839,9 +1838,9 @@ function searchPathForFile (file, proj) {
 }
 
 function nonComments (obj) {
-    var keys = Object.keys(obj),
-        newObj = {},
-        i = 0;
+    const keys = Object.keys(obj);
+    const newObj = {};
+    let i = 0;
 
     for (i; i < keys.length; i++) {
         if (!COMMENT_KEY.test(keys[i])) {
@@ -1904,13 +1903,13 @@ function filetypeForProducttype (productType) {
 
 pbxProject.prototype.getFirstProject = function () {
     // Get pbxProject container
-    var pbxProjectContainer = this.pbxProjectSection();
+    const pbxProjectContainer = this.pbxProjectSection();
 
     // Get first pbxProject UUID
-    var firstProjectUuid = Object.keys(pbxProjectContainer)[0];
+    const firstProjectUuid = Object.keys(pbxProjectContainer)[0];
 
     // Get first pbxProject
-    var firstProject = pbxProjectContainer[firstProjectUuid];
+    const firstProject = pbxProjectContainer[firstProjectUuid];
 
     return {
         uuid: firstProjectUuid,
@@ -1920,11 +1919,11 @@ pbxProject.prototype.getFirstProject = function () {
 
 pbxProject.prototype.getFirstTarget = function () {
     // Get first targets UUID
-    var firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0]
+    const firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0]
         .value;
 
     // Get first pbxNativeTarget
-    var firstTarget = this.pbxNativeTargetSection()[firstTargetUuid];
+    const firstTarget = this.pbxNativeTargetSection()[firstTargetUuid];
 
     return {
         uuid: firstTargetUuid,
@@ -1935,11 +1934,11 @@ pbxProject.prototype.getFirstTarget = function () {
 /** ** NEW ** **/
 
 pbxProject.prototype.addToPbxGroupType = function (file, groupKey, groupType) {
-    var group = this.getPBXGroupByKeyAndType(groupKey, groupType);
+    const group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group && group.children !== undefined) {
         if (typeof file === 'string') {
             // Group Key
-            var childGroup = {
+            const childGroup = {
                 value: file
             };
             if (this.getPBXGroupByKey(file)) {
@@ -1970,20 +1969,20 @@ pbxProject.prototype.pbxCreateGroupWithType = function (
     groupType
 ) {
     // Create object
-    var model = {
+    const model = {
         isa: '"' + groupType + '"',
         children: [],
         name: name,
         sourceTree: '"<group>"'
     };
     if (pathName) model.path = pathName;
-    var key = this.generateUuid();
+    const key = this.generateUuid();
 
     // Create comment
-    var commendId = key + '_comment';
+    const commendId = key + '_comment';
 
     // add obj and commentObj to groups;
-    var groups = this.hash.project.objects[groupType];
+    let groups = this.hash.project.objects[groupType];
     if (!groups) {
         groups = this.hash.project.objects[groupType] = {};
     }
@@ -2006,10 +2005,10 @@ pbxProject.prototype.removeFromPbxGroupAndType = function (
     groupKey,
     groupType
 ) {
-    var group = this.getPBXGroupByKeyAndType(groupKey, groupType);
+    const group = this.getPBXGroupByKeyAndType(groupKey, groupType);
     if (group) {
-        var groupChildren = group.children,
-            i;
+        const groupChildren = group.children;
+        let i;
         for (i in groupChildren) {
             if (
                 pbxGroupChild(file).value === groupChildren[i].value &&
@@ -2043,14 +2042,14 @@ pbxProject.prototype.getPBXVariantGroupByKey = function (key) {
 };
 
 pbxProject.prototype.findPBXGroupKeyAndType = function (criteria, groupType) {
-    var groups = this.hash.project.objects[groupType];
-    var target;
+    const groups = this.hash.project.objects[groupType];
+    let target;
 
-    for (var key in groups) {
+    for (const key in groups) {
         // only look for comments
         if (COMMENT_KEY.test(key)) continue;
 
-        var group = groups[key];
+        const group = groups[key];
         if (criteria && criteria.path && criteria.name) {
             if (
                 criteria.path === group.path &&
@@ -2084,12 +2083,12 @@ pbxProject.prototype.findPBXVariantGroupKey = function (criteria) {
 };
 
 pbxProject.prototype.addLocalizationVariantGroup = function (name) {
-    var groupKey = this.pbxCreateVariantGroup(name);
+    const groupKey = this.pbxCreateVariantGroup(name);
 
-    var resourceGroupKey = this.findPBXGroupKey({ name: 'Resources' });
+    const resourceGroupKey = this.findPBXGroupKey({ name: 'Resources' });
     this.addToPbxGroup(groupKey, resourceGroupKey);
 
-    var localizationVariantGroup = {
+    const localizationVariantGroup = {
         uuid: this.generateUuid(),
         fileRef: groupKey,
         basename: name
@@ -2118,11 +2117,11 @@ pbxProject.prototype.addKnownRegion = function (name) {
 };
 
 pbxProject.prototype.removeKnownRegion = function (name) {
-    var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
+    const regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
         'knownRegions'
     ];
     if (regions) {
-        for (var i = 0; i < regions.length; i++) {
+        for (let i = 0; i < regions.length; i++) {
             if (regions[i] === name) {
                 regions.splice(i, 1);
                 break;
@@ -2135,11 +2134,11 @@ pbxProject.prototype.removeKnownRegion = function (name) {
 };
 
 pbxProject.prototype.hasKnownRegion = function (name) {
-    var regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
+    const regions = this.pbxProjectSection()[this.getFirstProject()['uuid']][
         'knownRegions'
     ];
     if (regions) {
-        for (var i in regions) {
+        for (const i in regions) {
             if (regions[i] === name) {
                 return true;
             }
@@ -2153,7 +2152,7 @@ pbxProject.prototype.getPBXObject = function (name) {
 };
 
 pbxProject.prototype.addFile = function (path, group, opt) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
 
     // null is better for early errors
     if (this.hasFile(file.path)) return null;
@@ -2172,7 +2171,7 @@ pbxProject.prototype.addFile = function (path, group, opt) {
 };
 
 pbxProject.prototype.removeFile = function (path, group, opt) {
-    var file = new pbxFile(path, opt);
+    const file = new pbxFile(path, opt);
 
     this.removeFromPbxFileReferenceSection(file); // -- PBXFileReference
 
@@ -2186,11 +2185,11 @@ pbxProject.prototype.removeFile = function (path, group, opt) {
 };
 
 pbxProject.prototype.getBuildProperty = function (prop, build) {
-    var target;
-    var configs = this.pbxXCBuildConfigurationSection();
-    for (var configName in configs) {
+    let target;
+    const configs = this.pbxXCBuildConfigurationSection();
+    for (const configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
-            var config = configs[configName];
+            const config = configs[configName];
             if ((build && config.name === build) || build === undefined) {
                 if (config.buildSettings[prop] !== undefined) {
                     target = config.buildSettings[prop];
@@ -2202,11 +2201,11 @@ pbxProject.prototype.getBuildProperty = function (prop, build) {
 };
 
 pbxProject.prototype.getBuildConfigByName = function (name) {
-    var target = {};
-    var configs = this.pbxXCBuildConfigurationSection();
-    for (var configName in configs) {
+    const target = {};
+    const configs = this.pbxXCBuildConfigurationSection();
+    for (const configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
-            var config = configs[configName];
+            const config = configs[configName];
             if (config.name === name) {
                 target[configName] = config;
             }
@@ -2223,7 +2222,7 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
         group = this.findPBXGroupKey({ name: group });
     }
 
-    var file = new pbxFile(filePath, opt);
+    const file = new pbxFile(filePath, opt);
 
     if (!file || this.hasFile(file.path)) return null;
 
@@ -2239,11 +2238,11 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
     this.addToPbxSourcesBuildPhase(file);
 
     file.models = [];
-    var currentVersionName;
-    var modelFiles = fs.readdirSync(file.path);
-    for (var index in modelFiles) {
-        var modelFileName = modelFiles[index];
-        var modelFilePath = path.join(filePath, modelFileName);
+    let currentVersionName;
+    const modelFiles = fs.readdirSync(file.path);
+    for (const index in modelFiles) {
+        const modelFileName = modelFiles[index];
+        const modelFilePath = path.join(filePath, modelFileName);
 
         if (modelFileName === '.xccurrentversion') {
             currentVersionName = plist.readFileSync(modelFilePath)
@@ -2251,7 +2250,7 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
             continue;
         }
 
-        var modelFile = new pbxFile(modelFilePath);
+        const modelFile = new pbxFile(modelFilePath);
         modelFile.fileRef = this.generateUuid();
 
         this.addToPbxFileReferenceSection(modelFile);
@@ -2273,7 +2272,7 @@ pbxProject.prototype.addDataModelDocument = function (filePath, group, opt) {
 };
 
 pbxProject.prototype.addTargetAttribute = function (prop, value, target) {
-    var attributes = this.getFirstProject()['firstProject']['attributes'];
+    const attributes = this.getFirstProject()['firstProject']['attributes'];
     if (attributes['TargetAttributes'] === undefined) {
         attributes['TargetAttributes'] = {};
     }
@@ -2285,7 +2284,7 @@ pbxProject.prototype.addTargetAttribute = function (prop, value, target) {
 };
 
 pbxProject.prototype.removeTargetAttribute = function (prop, target) {
-    var attributes = this.getFirstProject()['firstProject']['attributes'];
+    const attributes = this.getFirstProject()['firstProject']['attributes'];
     target = target || this.getFirstTarget();
     if (
         attributes['TargetAttributes'] &&

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1185,7 +1185,9 @@ pbxProject.prototype.buildPhase = function (group, target) {
     var buildPhases = nativeTarget.buildPhases;
     for (var i in buildPhases) {
         var buildPhase = buildPhases[i];
-        if (buildPhase.comment === group) return buildPhase.value + '_comment';
+        if (buildPhase.comment === group) {
+            return buildPhase.value + '_comment';
+        }
     }
 };
 

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -15,13 +15,13 @@
  under the License.
  */
 
-var pbxProj = require('./pbxProject'),
-    util = require('util'),
-    f = util.format,
-    INDENT = '\t',
-    COMMENT_KEY = /_comment$/,
-    QUOTED = /^"(.*)"$/,
-    EventEmitter = require('events').EventEmitter;
+const pbxProj = require('./pbxProject');
+const util = require('util');
+const f = util.format;
+const INDENT = '\t';
+const COMMENT_KEY = /_comment$/;
+const QUOTED = /^"(.*)"$/;
+const EventEmitter = require('events').EventEmitter;
 
 // indentation
 function i (x) {
@@ -30,7 +30,7 @@ function i (x) {
 }
 
 function comment (key, parent) {
-    var text = parent[key + '_comment'];
+    const text = parent[key + '_comment'];
 
     if (text) return text;
     else return null;
@@ -62,7 +62,7 @@ function pbxWriter (contents, options) {
 util.inherits(pbxWriter, EventEmitter);
 
 pbxWriter.prototype.write = function (str) {
-    var fmt = f.apply(null, arguments);
+    const fmt = f.apply(null, arguments);
 
     if (this.sync) {
         this.buffer += f('%s%s', i(this.indentLevel), fmt);
@@ -72,7 +72,7 @@ pbxWriter.prototype.write = function (str) {
 };
 
 pbxWriter.prototype.writeFlush = function (str) {
-    var oldIndent = this.indentLevel;
+    const oldIndent = this.indentLevel;
 
     this.indentLevel = 0;
 
@@ -98,10 +98,10 @@ pbxWriter.prototype.writeHeadComment = function () {
 };
 
 pbxWriter.prototype.writeProject = function () {
-    var proj = this.contents.project,
-        key,
-        cmt,
-        obj;
+    const proj = this.contents.project;
+    let key;
+    let cmt;
+    let obj;
 
     this.write('{\n');
 
@@ -148,7 +148,7 @@ pbxWriter.prototype.writeProject = function () {
 };
 
 pbxWriter.prototype.writeObject = function (object) {
-    var key, obj, cmt;
+    let key, obj, cmt;
 
     for (key in object) {
         if (COMMENT_KEY.test(key)) continue;
@@ -179,7 +179,8 @@ pbxWriter.prototype.writeObject = function (object) {
 };
 
 pbxWriter.prototype.writeObjectsSections = function (objects) {
-    var key, obj;
+    let key;
+    let obj;
 
     for (key in objects) {
         this.writeFlush('\n');
@@ -197,7 +198,7 @@ pbxWriter.prototype.writeObjectsSections = function (objects) {
 };
 
 pbxWriter.prototype.writeArray = function (arr, name) {
-    var i, entry;
+    let i, entry;
 
     this.write('%s = (\n', name);
     this.indentLevel++;
@@ -234,7 +235,7 @@ pbxWriter.prototype.writeSectionComment = function (name, begin) {
 };
 
 pbxWriter.prototype.writeSection = function (section) {
-    var key, obj, cmt;
+    let key, obj, cmt;
 
     // section should only contain objects
     for (key in section) {
@@ -263,11 +264,11 @@ pbxWriter.prototype.writeSection = function (section) {
 };
 
 pbxWriter.prototype.writeInlineObject = function (n, d, r) {
-    var output = [];
-    var self = this;
+    const output = [];
+    const self = this;
 
-    var inlineObjectHelper = function (name, desc, ref) {
-        var key, cmt, obj;
+    const inlineObjectHelper = function (name, desc, ref) {
+        let key, cmt, obj;
 
         if (desc) {
             output.push(f('%s /* %s */ = {', name, desc));
@@ -284,7 +285,7 @@ pbxWriter.prototype.writeInlineObject = function (n, d, r) {
             if (isArray(obj)) {
                 output.push(f('%s = (', key));
 
-                for (var i = 0; i < obj.length; i++) {
+                for (let i = 0; i < obj.length; i++) {
                     output.push(f('%s, ', obj[i]));
                 }
 

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -21,46 +21,42 @@ var pbxProj = require('./pbxProject'),
     INDENT = '\t',
     COMMENT_KEY = /_comment$/,
     QUOTED = /^"(.*)"$/,
-    EventEmitter = require('events').EventEmitter
+    EventEmitter = require('events').EventEmitter;
 
 // indentation
-function i(x) {
-    if (x <=0)
-        return '';
-    else
-        return INDENT + i(x-1);
+function i (x) {
+    if (x <= 0) return '';
+    else return INDENT + i(x - 1);
 }
 
-function comment(key, parent) {
+function comment (key, parent) {
     var text = parent[key + '_comment'];
 
-    if (text)
-        return text;
-    else
-        return null;
+    if (text) return text;
+    else return null;
 }
 
 // copied from underscore
-function isObject(obj) {
-    return obj === Object(obj)
+function isObject (obj) {
+    return obj === Object(obj);
 }
 
-function isArray(obj) {
-    return Array.isArray(obj)
+function isArray (obj) {
+    return Array.isArray(obj);
 }
 
-function pbxWriter(contents, options) {
+function pbxWriter (contents, options) {
     if (!options) {
-        options = {}
+        options = {};
     }
     if (options.omitEmptyValues === undefined) {
-        options.omitEmptyValues = false
+        options.omitEmptyValues = false;
     }
 
     this.contents = contents;
     this.sync = false;
     this.indentLevel = 0;
-    this.omitEmptyValues = options.omitEmptyValues
+    this.omitEmptyValues = options.omitEmptyValues;
 }
 
 util.inherits(pbxWriter, EventEmitter);
@@ -69,43 +65,45 @@ pbxWriter.prototype.write = function (str) {
     var fmt = f.apply(null, arguments);
 
     if (this.sync) {
-        this.buffer += f("%s%s", i(this.indentLevel), fmt);
+        this.buffer += f('%s%s', i(this.indentLevel), fmt);
     } else {
         // do stream write
     }
-}
+};
 
 pbxWriter.prototype.writeFlush = function (str) {
     var oldIndent = this.indentLevel;
 
     this.indentLevel = 0;
 
-    this.write.apply(this, arguments)
+    this.write.apply(this, arguments);
 
     this.indentLevel = oldIndent;
-}
+};
 
 pbxWriter.prototype.writeSync = function () {
     this.sync = true;
-    this.buffer = "";
+    this.buffer = '';
 
     this.writeHeadComment();
     this.writeProject();
 
     return this.buffer;
-}
+};
 
 pbxWriter.prototype.writeHeadComment = function () {
     if (this.contents.headComment) {
-        this.write("// %s\n", this.contents.headComment)
+        this.write('// %s\n', this.contents.headComment);
     }
-}
+};
 
 pbxWriter.prototype.writeProject = function () {
     var proj = this.contents.project,
-        key, cmt, obj;
+        key,
+        cmt,
+        obj;
 
-    this.write("{\n")
+    this.write('{\n');
 
     if (proj) {
         this.indentLevel++;
@@ -118,33 +116,36 @@ pbxWriter.prototype.writeProject = function () {
             obj = proj[key];
 
             if (isArray(obj)) {
-                this.writeArray(obj, key)
+                this.writeArray(obj, key);
             } else if (isObject(obj)) {
-                this.write("%s = {\n", key);
+                this.write('%s = {\n', key);
                 this.indentLevel++;
 
                 if (key === 'objects') {
-                    this.writeObjectsSections(obj)
+                    this.writeObjectsSections(obj);
                 } else {
-                    this.writeObject(obj)
+                    this.writeObject(obj);
                 }
 
                 this.indentLevel--;
-                this.write("};\n");
-            } else if (this.omitEmptyValues && (obj === undefined || obj === null)) {
+                this.write('};\n');
+            } else if (
+                this.omitEmptyValues &&
+                (obj === undefined || obj === null)
+            ) {
                 continue;
             } else if (cmt) {
-                this.write("%s = %s /* %s */;\n", key, obj, cmt)
+                this.write('%s = %s /* %s */;\n', key, obj, cmt);
             } else {
-                this.write("%s = %s;\n", key, obj)
+                this.write('%s = %s;\n', key, obj);
             }
         }
 
         this.indentLevel--;
     }
 
-    this.write("}\n")
-}
+    this.write('}\n');
+};
 
 pbxWriter.prototype.writeObject = function (object) {
     var key, obj, cmt;
@@ -156,34 +157,35 @@ pbxWriter.prototype.writeObject = function (object) {
         obj = object[key];
 
         if (isArray(obj)) {
-            this.writeArray(obj, key)
+            this.writeArray(obj, key);
         } else if (isObject(obj)) {
-            this.write("%s = {\n", key);
+            this.write('%s = {\n', key);
             this.indentLevel++;
 
-            this.writeObject(obj)
+            this.writeObject(obj);
 
             this.indentLevel--;
-            this.write("};\n");
+            this.write('};\n');
         } else {
             if (this.omitEmptyValues && (obj === undefined || obj === null)) {
                 continue;
             } else if (cmt) {
-                this.write("%s = %s /* %s */;\n", key, obj, cmt)
+                this.write('%s = %s /* %s */;\n', key, obj, cmt);
             } else {
-                this.write("%s = %s;\n", key, obj)
+                this.write('%s = %s;\n', key, obj);
             }
         }
     }
-}
+};
 
 pbxWriter.prototype.writeObjectsSections = function (objects) {
     var first = true,
-        key, obj;
+        key,
+        obj;
 
     for (key in objects) {
         if (!first) {
-            this.writeFlush("\n")
+            this.writeFlush('\n');
         } else {
             first = false;
         }
@@ -198,16 +200,16 @@ pbxWriter.prototype.writeObjectsSections = function (objects) {
             this.writeSectionComment(key, false);
         }
     }
-}
+};
 
 pbxWriter.prototype.writeArray = function (arr, name) {
     var i, entry;
 
-    this.write("%s = (\n", name);
+    this.write('%s = (\n', name);
     this.indentLevel++;
 
-    for (i=0; i < arr.length; i++) {
-        entry = arr[i]
+    for (i = 0; i < arr.length; i++) {
+        entry = arr[i];
 
         if (entry.value && entry.comment) {
             this.write('%s /* %s */,\n', entry.value, entry.comment);
@@ -225,16 +227,17 @@ pbxWriter.prototype.writeArray = function (arr, name) {
     }
 
     this.indentLevel--;
-    this.write(");\n");
-}
+    this.write(');\n');
+};
 
 pbxWriter.prototype.writeSectionComment = function (name, begin) {
     if (begin) {
-        this.writeFlush("/* Begin %s section */\n", name)
-    } else { // end
-        this.writeFlush("/* End %s section */\n", name)
+        this.writeFlush('/* Begin %s section */\n', name);
+    } else {
+        // end
+        this.writeFlush('/* End %s section */\n', name);
     }
-}
+};
 
 pbxWriter.prototype.writeSection = function (section) {
     var key, obj, cmt;
@@ -244,38 +247,38 @@ pbxWriter.prototype.writeSection = function (section) {
         if (COMMENT_KEY.test(key)) continue;
 
         cmt = comment(key, section);
-        obj = section[key]
+        obj = section[key];
 
         if (obj.isa == 'PBXBuildFile' || obj.isa == 'PBXFileReference') {
             this.writeInlineObject(key, cmt, obj);
         } else {
             if (cmt) {
-                this.write("%s /* %s */ = {\n", key, cmt);
+                this.write('%s /* %s */ = {\n', key, cmt);
             } else {
-                this.write("%s = {\n", key);
+                this.write('%s = {\n', key);
             }
 
-            this.indentLevel++
+            this.indentLevel++;
 
-            this.writeObject(obj)
+            this.writeObject(obj);
 
-            this.indentLevel--
-            this.write("};\n");
+            this.indentLevel--;
+            this.write('};\n');
         }
     }
-}
+};
 
 pbxWriter.prototype.writeInlineObject = function (n, d, r) {
     var output = [];
-    var self = this
+    var self = this;
 
     var inlineObjectHelper = function (name, desc, ref) {
         var key, cmt, obj;
 
         if (desc) {
-            output.push(f("%s /* %s */ = {", name, desc));
+            output.push(f('%s /* %s */ = {', name, desc));
         } else {
-            output.push(f("%s = {", name));
+            output.push(f('%s = {', name));
         }
 
         for (key in ref) {
@@ -285,30 +288,33 @@ pbxWriter.prototype.writeInlineObject = function (n, d, r) {
             obj = ref[key];
 
             if (isArray(obj)) {
-                output.push(f("%s = (", key));
+                output.push(f('%s = (', key));
 
-                for (var i=0; i < obj.length; i++) {
-                    output.push(f("%s, ", obj[i]))
+                for (var i = 0; i < obj.length; i++) {
+                    output.push(f('%s, ', obj[i]));
                 }
 
-                output.push("); ");
+                output.push('); ');
             } else if (isObject(obj)) {
-                inlineObjectHelper(key, cmt, obj)
-            } else if (self.omitEmptyValues && (obj === undefined || obj === null)) {
+                inlineObjectHelper(key, cmt, obj);
+            } else if (
+                self.omitEmptyValues &&
+                (obj === undefined || obj === null)
+            ) {
                 continue;
             } else if (cmt) {
-                output.push(f("%s = %s /* %s */; ", key, obj, cmt))
+                output.push(f('%s = %s /* %s */; ', key, obj, cmt));
             } else {
-                output.push(f("%s = %s; ", key, obj))
+                output.push(f('%s = %s; ', key, obj));
             }
         }
 
-        output.push("}; ");
-    }
+        output.push('}; ');
+    };
 
     inlineObjectHelper(n, d, r);
 
-    this.write("%s\n", output.join('').trim());
-}
+    this.write('%s\n', output.join('').trim());
+};
 
 module.exports = pbxWriter;

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -182,7 +182,7 @@ pbxWriter.prototype.writeObjectsSections = function (objects) {
     var key, obj;
 
     for (key in objects) {
-        this.writeFlush("\n")
+        this.writeFlush('\n');
 
         obj = objects[key];
 

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -99,21 +99,18 @@ pbxWriter.prototype.writeHeadComment = function () {
 
 pbxWriter.prototype.writeProject = function () {
     const proj = this.contents.project;
-    let key;
-    let cmt;
-    let obj;
 
     this.write('{\n');
 
     if (proj) {
         this.indentLevel++;
 
-        for (key in proj) {
+        for (const key in proj) {
             // skip comments
             if (COMMENT_KEY.test(key)) continue;
 
-            cmt = comment(key, proj);
-            obj = proj[key];
+            const cmt = comment(key, proj);
+            const obj = proj[key];
 
             if (isArray(obj)) {
                 this.writeArray(obj, key);
@@ -148,13 +145,11 @@ pbxWriter.prototype.writeProject = function () {
 };
 
 pbxWriter.prototype.writeObject = function (object) {
-    let key, obj, cmt;
-
-    for (key in object) {
+    for (const key in object) {
         if (COMMENT_KEY.test(key)) continue;
 
-        cmt = comment(key, object);
-        obj = object[key];
+        const cmt = comment(key, object);
+        const obj = object[key];
 
         if (isArray(obj)) {
             this.writeArray(obj, key);
@@ -179,13 +174,10 @@ pbxWriter.prototype.writeObject = function (object) {
 };
 
 pbxWriter.prototype.writeObjectsSections = function (objects) {
-    let key;
-    let obj;
-
-    for (key in objects) {
+    for (const key in objects) {
         this.writeFlush('\n');
 
-        obj = objects[key];
+        const obj = objects[key];
 
         if (isObject(obj)) {
             this.writeSectionComment(key, true);
@@ -198,14 +190,10 @@ pbxWriter.prototype.writeObjectsSections = function (objects) {
 };
 
 pbxWriter.prototype.writeArray = function (arr, name) {
-    let i, entry;
-
     this.write('%s = (\n', name);
     this.indentLevel++;
 
-    for (i = 0; i < arr.length; i++) {
-        entry = arr[i];
-
+    for (const entry in arr) {
         if (entry.value && entry.comment) {
             this.write('%s /* %s */,\n', entry.value, entry.comment);
         } else if (isObject(entry)) {
@@ -235,14 +223,12 @@ pbxWriter.prototype.writeSectionComment = function (name, begin) {
 };
 
 pbxWriter.prototype.writeSection = function (section) {
-    let key, obj, cmt;
-
     // section should only contain objects
-    for (key in section) {
+    for (const key in section) {
         if (COMMENT_KEY.test(key)) continue;
 
-        cmt = comment(key, section);
-        obj = section[key];
+        const cmt = comment(key, section);
+        const obj = section[key];
 
         if (obj.isa === 'PBXBuildFile' || obj.isa === 'PBXFileReference') {
             this.writeInlineObject(key, cmt, obj);
@@ -268,25 +254,23 @@ pbxWriter.prototype.writeInlineObject = function (n, d, r) {
     const self = this;
 
     const inlineObjectHelper = function (name, desc, ref) {
-        let key, cmt, obj;
-
         if (desc) {
             output.push(f('%s /* %s */ = {', name, desc));
         } else {
             output.push(f('%s = {', name));
         }
 
-        for (key in ref) {
+        for (const key in ref) {
             if (COMMENT_KEY.test(key)) continue;
 
-            cmt = comment(key, ref);
-            obj = ref[key];
+            const cmt = comment(key, ref);
+            const obj = ref[key];
 
             if (isArray(obj)) {
                 output.push(f('%s = (', key));
 
-                for (let i = 0; i < obj.length; i++) {
-                    output.push(f('%s, ', obj[i]));
+                for (const entry in obj) {
+                    output.push(f('%s, ', entry));
                 }
 
                 output.push('); ');

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -99,18 +99,21 @@ pbxWriter.prototype.writeHeadComment = function () {
 
 pbxWriter.prototype.writeProject = function () {
     const proj = this.contents.project;
+    let key;
+    let cmt;
+    let obj;
 
     this.write('{\n');
 
     if (proj) {
         this.indentLevel++;
 
-        for (const key in proj) {
+        for (key in proj) {
             // skip comments
             if (COMMENT_KEY.test(key)) continue;
 
-            const cmt = comment(key, proj);
-            const obj = proj[key];
+            cmt = comment(key, proj);
+            obj = proj[key];
 
             if (isArray(obj)) {
                 this.writeArray(obj, key);
@@ -145,11 +148,13 @@ pbxWriter.prototype.writeProject = function () {
 };
 
 pbxWriter.prototype.writeObject = function (object) {
-    for (const key in object) {
+    let key, obj, cmt;
+
+    for (key in object) {
         if (COMMENT_KEY.test(key)) continue;
 
-        const cmt = comment(key, object);
-        const obj = object[key];
+        cmt = comment(key, object);
+        obj = object[key];
 
         if (isArray(obj)) {
             this.writeArray(obj, key);
@@ -174,10 +179,13 @@ pbxWriter.prototype.writeObject = function (object) {
 };
 
 pbxWriter.prototype.writeObjectsSections = function (objects) {
-    for (const key in objects) {
+    let key;
+    let obj;
+
+    for (key in objects) {
         this.writeFlush('\n');
 
-        const obj = objects[key];
+        obj = objects[key];
 
         if (isObject(obj)) {
             this.writeSectionComment(key, true);
@@ -190,10 +198,14 @@ pbxWriter.prototype.writeObjectsSections = function (objects) {
 };
 
 pbxWriter.prototype.writeArray = function (arr, name) {
+    let i, entry;
+
     this.write('%s = (\n', name);
     this.indentLevel++;
 
-    for (const entry in arr) {
+    for (i = 0; i < arr.length; i++) {
+        entry = arr[i];
+
         if (entry.value && entry.comment) {
             this.write('%s /* %s */,\n', entry.value, entry.comment);
         } else if (isObject(entry)) {
@@ -223,12 +235,14 @@ pbxWriter.prototype.writeSectionComment = function (name, begin) {
 };
 
 pbxWriter.prototype.writeSection = function (section) {
+    let key, obj, cmt;
+
     // section should only contain objects
-    for (const key in section) {
+    for (key in section) {
         if (COMMENT_KEY.test(key)) continue;
 
-        const cmt = comment(key, section);
-        const obj = section[key];
+        cmt = comment(key, section);
+        obj = section[key];
 
         if (obj.isa === 'PBXBuildFile' || obj.isa === 'PBXFileReference') {
             this.writeInlineObject(key, cmt, obj);
@@ -254,23 +268,25 @@ pbxWriter.prototype.writeInlineObject = function (n, d, r) {
     const self = this;
 
     const inlineObjectHelper = function (name, desc, ref) {
+        let key, cmt, obj;
+
         if (desc) {
             output.push(f('%s /* %s */ = {', name, desc));
         } else {
             output.push(f('%s = {', name));
         }
 
-        for (const key in ref) {
+        for (key in ref) {
             if (COMMENT_KEY.test(key)) continue;
 
-            const cmt = comment(key, ref);
-            const obj = ref[key];
+            cmt = comment(key, ref);
+            obj = ref[key];
 
             if (isArray(obj)) {
                 output.push(f('%s = (', key));
 
-                for (const entry in obj) {
-                    output.push(f('%s, ', entry));
+                for (let i = 0; i < obj.length; i++) {
+                    output.push(f('%s, ', obj[i]));
                 }
 
                 output.push('); ');

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -249,7 +249,7 @@ pbxWriter.prototype.writeSection = function (section) {
         cmt = comment(key, section);
         obj = section[key];
 
-        if (obj.isa == 'PBXBuildFile' || obj.isa == 'PBXFileReference') {
+        if (obj.isa === 'PBXBuildFile' || obj.isa === 'PBXFileReference') {
             this.writeInlineObject(key, cmt, obj);
         } else {
             if (cmt) {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "nodeunit": "^0.11.3",
-    "pegjs": "^0.10.0"
+    "pegjs": "^0.10.0",
+    "prettier-eslint": "^8.8.2"
   },
   "scripts": {
     "eslint": "eslint lib test",
     "eslint:lib": "eslint lib",
     "eslint:test": "eslint test",
     "pegjs": "node_modules/.bin/pegjs lib/parser/pbxproj.pegjs",
+    "prettier": "npm run prettier:lib && npm run prettier:test",
+    "prettier:lib": "prettier-eslint --print-width 78 --tab-width 4 --single-quote --write lib/*.js",
+    "prettier:test": "prettier-eslint --print-width 78 --tab-width 4 --single-quote --write test/*.js test/parser/*.js",
     "test": "node_modules/.bin/nodeunit test/parser test"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,19 @@
     "uuid": "3.0.1"
   },
   "devDependencies": {
+    "eslint": "^5.10.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "nodeunit": "^0.11.3",
     "pegjs": "^0.10.0"
   },
   "scripts": {
+    "eslint": "eslint lib test",
+    "eslint:lib": "eslint lib",
+    "eslint:test": "eslint test",
     "pegjs": "node_modules/.bin/pegjs lib/parser/pbxproj.pegjs",
     "test": "node_modules/.bin/nodeunit test/parser test"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prettier": "npm run prettier:lib && npm run prettier:test",
     "prettier:lib": "prettier-eslint --print-width 78 --tab-width 4 --single-quote --write lib/*.js",
     "prettier:test": "prettier-eslint --print-width 78 --tab-width 4 --single-quote --write test/*.js test/parser/*.js",
-    "test": "node_modules/.bin/nodeunit test/parser test"
+    "test": "npm run eslint && node_modules/.bin/nodeunit test/parser test",
+    "test:unit": "node_modules/.bin/nodeunit test/parser test"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,6 +2,10 @@ rules:
   # Specific to test:
   handle-callback-err: off
 
+  # TODO FIX these in test:
+  no-var: off
+  prefer-const: off
+
   # TODO: Resolve the issues in the tests so that these rules can be re-enabled:
   curly: off
   eqeqeq: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -3,29 +3,16 @@ rules:
   handle-callback-err: off
 
   # TODO: Resolve the issues in the tests so that these rules can be re-enabled:
-  comma-dangle: off
-  comma-spacing: off
-  comma-style: off
   curly: off
   eqeqeq: off
-  func-call-spacing: off
-  key-spacing: off
   new-cap: off
-  no-multi-spaces: off
-  no-multiple-empty-lines: off
   no-path-concat: off
   no-redeclare: off
   no-regex-spaces: off
   no-sequences: off
-  no-tabs: off
   no-template-curly-in-string: off
   no-undef: off
   no-unused-expressions: off
   no-unused-vars: off
   no-use-before-define: off
-  object-curly-spacing: off
   one-var: off
-  padded-blocks: off
-  quotes: off
-  space-infix-ops: off
-  standard/object-curly-even-spacing: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -9,7 +9,6 @@ rules:
   curly: off
   eqeqeq: off
   func-call-spacing: off
-  indent: off
   key-spacing: off
   new-cap: off
   no-multi-spaces: off
@@ -28,9 +27,5 @@ rules:
   one-var: off
   padded-blocks: off
   quotes: off
-  semi: off
-  space-before-blocks: off
-  space-before-function-paren: off
-  space-in-parens: off
   space-infix-ops: off
   standard/object-curly-even-spacing: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,36 @@
+rules:
+  # Specific to test:
+  handle-callback-err: off
+
+  # TODO: Resolve the issues in the tests so that these rules can be re-enabled:
+  comma-dangle: off
+  comma-spacing: off
+  comma-style: off
+  curly: off
+  eqeqeq: off
+  func-call-spacing: off
+  indent: off
+  key-spacing: off
+  new-cap: off
+  no-multi-spaces: off
+  no-multiple-empty-lines: off
+  no-path-concat: off
+  no-redeclare: off
+  no-regex-spaces: off
+  no-sequences: off
+  no-tabs: off
+  no-template-curly-in-string: off
+  no-undef: off
+  no-unused-expressions: off
+  no-unused-vars: off
+  no-use-before-define: off
+  object-curly-spacing: off
+  one-var: off
+  padded-blocks: off
+  quotes: off
+  semi: off
+  space-before-blocks: off
+  space-before-function-paren: off
+  space-in-parens: off
+  space-infix-ops: off
+  standard/object-curly-even-spacing: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,10 +2,6 @@ rules:
   # Specific to test:
   handle-callback-err: off
 
-  # TODO FIX these in test:
-  no-var: off
-  prefer-const: off
-
   # TODO: Resolve the issues in the tests so that these rules can be re-enabled:
   curly: off
   eqeqeq: off
@@ -19,4 +15,3 @@ rules:
   no-unused-expressions: off
   no-unused-vars: off
   no-use-before-define: off
-  one-var: off

--- a/test/BuildSettings.js
+++ b/test/BuildSettings.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -30,17 +30,17 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"KitchenSinktablet"';
+const PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromBuildSettings = {
     'add should add the build setting to each configuration section': function (
         test
     ) {
-        var buildSetting = 'some/buildSetting';
-        var value = 'some/buildSetting';
+        const buildSetting = 'some/buildSetting';
+        const value = 'some/buildSetting';
         proj.addToBuildSettings(buildSetting, value);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
@@ -53,11 +53,11 @@ exports.addAndRemoveToFromBuildSettings = {
     'remove should remove from the build settings in each configuration section': function (
         test
     ) {
-        var buildSetting = 'some/buildSetting';
+        const buildSetting = 'some/buildSetting';
         proj.addToBuildSettings(buildSetting, 'some/buildSetting');
         proj.removeFromBuildSettings(buildSetting);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME

--- a/test/BuildSettings.js
+++ b/test/BuildSettings.js
@@ -21,38 +21,50 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromBuildSettings = {
-    'add should add the build setting to each configuration section':function(test) {
+    'add should add the build setting to each configuration section': function (
+        test
+    ) {
         var buildSetting = 'some/buildSetting';
         var value = 'some/buildSetting';
         proj.addToBuildSettings(buildSetting, value);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             test.ok(config[ref].buildSettings[buildSetting] === value);
         }
         test.done();
     },
-    'remove should remove from the build settings in each configuration section':function(test) {
+    'remove should remove from the build settings in each configuration section': function (
+        test
+    ) {
         var buildSetting = 'some/buildSetting';
         proj.addToBuildSettings(buildSetting, 'some/buildSetting');
         proj.removeFromBuildSettings(buildSetting);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             test.ok(!config[ref].buildSettings.hasOwnProperty(buildSetting));
         }
         test.done();
     }
-}
+};

--- a/test/BuildSettings.js
+++ b/test/BuildSettings.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/FrameworkSearchPaths.js
+++ b/test/FrameworkSearchPaths.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/FrameworkSearchPaths.js
+++ b/test/FrameworkSearchPaths.js
@@ -15,17 +15,21 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
 
-var pbxFile = {
+// XXX TBD ???:
+// var pbxFile = require('../lib/pbxFile');
+
+const proj = new pbx('.');
+
+const pbxFile = {
     path: 'some/path/include',
     dirname: 'some/path',
     customFramework: true
 };
+
 function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
@@ -35,19 +39,19 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"KitchenSinktablet"';
+const PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromFrameworkSearchPaths = {
     'add should add the path to each configuration section': function (test) {
         proj.addToFrameworkSearchPaths(pbxFile);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
             test.ok(lib[1].indexOf('some/path') > -1);
         }
         test.done();
@@ -57,14 +61,14 @@ exports.addAndRemoveToFromFrameworkSearchPaths = {
     ) {
         proj.addToFrameworkSearchPaths(pbxFile);
         proj.removeFromFrameworkSearchPaths(pbxFile);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
             test.ok(lib.length === 1);
             test.ok(lib[0].indexOf('some/path') == -1);
         }

--- a/test/FrameworkSearchPaths.js
+++ b/test/FrameworkSearchPaths.js
@@ -22,42 +22,52 @@ var fullProject = require('./fixtures/full-project'),
     proj = new pbx('.');
 
 var pbxFile = {
-  path:'some/path/include',
-  dirname: 'some/path',
-  customFramework: true
-}
-function cleanHash() {
+    path: 'some/path/include',
+    dirname: 'some/path',
+    customFramework: true
+};
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromFrameworkSearchPaths = {
-    'add should add the path to each configuration section':function(test) {
+    'add should add the path to each configuration section': function (test) {
         proj.addToFrameworkSearchPaths(pbxFile);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
             test.ok(lib[1].indexOf('some/path') > -1);
         }
         test.done();
     },
-    'remove should remove from the path to each configuration section':function(test) {
+    'remove should remove from the path to each configuration section': function (
+        test
+    ) {
         proj.addToFrameworkSearchPaths(pbxFile);
         proj.removeFromFrameworkSearchPaths(pbxFile);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.FRAMEWORK_SEARCH_PATHS;
             test.ok(lib.length === 1);
             test.ok(lib[0].indexOf('some/path') == -1);
         }
         test.done();
     }
-}
+};

--- a/test/HeaderSearchPaths.js
+++ b/test/HeaderSearchPaths.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -30,21 +30,21 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"KitchenSinktablet"';
+const PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromHeaderSearchPaths = {
     'add should add the path to each configuration section': function (test) {
         proj.addToHeaderSearchPaths({
             path: 'some/path/include'
         });
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
             test.ok(
                 lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1
             );
@@ -54,16 +54,16 @@ exports.addAndRemoveToFromHeaderSearchPaths = {
     'add should not mangle string arguments and add to each config section': function (
         test
     ) {
-        var includePath = '../../some/path';
+        const includePath = '../../some/path';
         proj.addToHeaderSearchPaths(includePath);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
             test.ok(lib[1].indexOf(includePath) > -1);
         }
         test.done();
@@ -71,21 +71,21 @@ exports.addAndRemoveToFromHeaderSearchPaths = {
     'remove should remove from the path to each configuration section': function (
         test
     ) {
-        var libPath = 'some/path/include';
+        const libPath = 'some/path/include';
         proj.addToHeaderSearchPaths({
             path: libPath
         });
         proj.removeFromHeaderSearchPaths({
             path: libPath
         });
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
             test.ok(lib.length === 1);
             test.ok(
                 lib[0].indexOf(

--- a/test/HeaderSearchPaths.js
+++ b/test/HeaderSearchPaths.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/HeaderSearchPaths.js
+++ b/test/HeaderSearchPaths.js
@@ -21,56 +21,78 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromHeaderSearchPaths = {
-    'add should add the path to each configuration section':function(test) {
+    'add should add the path to each configuration section': function (test) {
         proj.addToHeaderSearchPaths({
-            path:'some/path/include'
+            path: 'some/path/include'
         });
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
-            test.ok(lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1);
+            test.ok(
+                lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1
+            );
         }
         test.done();
     },
-    'add should not mangle string arguments and add to each config section':function(test) {
+    'add should not mangle string arguments and add to each config section': function (
+        test
+    ) {
         var includePath = '../../some/path';
         proj.addToHeaderSearchPaths(includePath);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
             test.ok(lib[1].indexOf(includePath) > -1);
         }
         test.done();
     },
-    'remove should remove from the path to each configuration section':function(test) {
+    'remove should remove from the path to each configuration section': function (
+        test
+    ) {
         var libPath = 'some/path/include';
         proj.addToHeaderSearchPaths({
-            path:libPath
+            path: libPath
         });
         proj.removeFromHeaderSearchPaths({
-            path:libPath
+            path: libPath
         });
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
             test.ok(lib.length === 1);
-            test.ok(lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path/include') == -1);
+            test.ok(
+                lib[0].indexOf(
+                    '$(SRCROOT)/KitchenSinktablet/some/path/include'
+                ) == -1
+            );
         }
         test.done();
     }
-}
+};

--- a/test/LibrarySearchPaths.js
+++ b/test/LibrarySearchPaths.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -30,21 +30,21 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"KitchenSinktablet"';
+const PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromLibrarySearchPaths = {
     'add should add the path to each configuration section': function (test) {
         proj.addToLibrarySearchPaths({
             path: 'some/path/poop.a'
         });
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(
                 lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1
             );
@@ -54,16 +54,16 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
     'add should not mangle string arguments and add to each config section': function (
         test
     ) {
-        var libPath = '../../some/path';
+        const libPath = '../../some/path';
         proj.addToLibrarySearchPaths(libPath);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(lib[1].indexOf(libPath) > -1);
         }
         test.done();
@@ -71,21 +71,21 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
     'remove should remove from the path to each configuration section': function (
         test
     ) {
-        var libPath = 'some/path/poop.a';
+        const libPath = 'some/path/poop.a';
         proj.addToLibrarySearchPaths({
             path: libPath
         });
         proj.removeFromLibrarySearchPaths({
             path: libPath
         });
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
+            const lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(lib.length === 1);
             test.ok(
                 lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') == -1

--- a/test/LibrarySearchPaths.js
+++ b/test/LibrarySearchPaths.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/LibrarySearchPaths.js
+++ b/test/LibrarySearchPaths.js
@@ -21,56 +21,76 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromLibrarySearchPaths = {
-    'add should add the path to each configuration section':function(test) {
+    'add should add the path to each configuration section': function (test) {
         proj.addToLibrarySearchPaths({
-            path:'some/path/poop.a'
+            path: 'some/path/poop.a'
         });
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
-            test.ok(lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1);
+            test.ok(
+                lib[1].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') > -1
+            );
         }
         test.done();
     },
-    'add should not mangle string arguments and add to each config section':function(test) {
+    'add should not mangle string arguments and add to each config section': function (
+        test
+    ) {
         var libPath = '../../some/path';
         proj.addToLibrarySearchPaths(libPath);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(lib[1].indexOf(libPath) > -1);
         }
         test.done();
     },
-    'remove should remove from the path to each configuration section':function(test) {
+    'remove should remove from the path to each configuration section': function (
+        test
+    ) {
         var libPath = 'some/path/poop.a';
         proj.addToLibrarySearchPaths({
-            path:libPath
+            path: libPath
         });
         proj.removeFromLibrarySearchPaths({
-            path:libPath
+            path: libPath
         });
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(lib.length === 1);
-            test.ok(lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') == -1);
+            test.ok(
+                lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') == -1
+            );
         }
         test.done();
     }
-}
+};

--- a/test/OtherLinkerFlags.js
+++ b/test/OtherLinkerFlags.js
@@ -21,40 +21,50 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromOtherLinkerFlags = {
-    'add should add the flag to each configuration section':function(test) {
+    'add should add the flag to each configuration section': function (test) {
         var flag = 'some/flag';
         proj.addToOtherLinkerFlags(flag);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.OTHER_LDFLAGS;
             test.ok(lib[1].indexOf(flag) > -1);
         }
         test.done();
     },
-    'remove should remove from the path to each configuration section':function(test) {
+    'remove should remove from the path to each configuration section': function (
+        test
+    ) {
         var flag = 'some/flag';
         proj.addToOtherLinkerFlags(flag);
         proj.removeFromOtherLinkerFlags(flag);
         var config = proj.pbxXCBuildConfigurationSection();
         for (var ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
             var lib = config[ref].buildSettings.OTHER_LDFLAGS;
             test.ok(lib.length === 1);
             test.ok(lib[0].indexOf(flag) == -1);
         }
         test.done();
     }
-}
+};

--- a/test/OtherLinkerFlags.js
+++ b/test/OtherLinkerFlags.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -30,20 +30,20 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"KitchenSinktablet"';
+const PRODUCT_NAME = '"KitchenSinktablet"';
 
 exports.addAndRemoveToFromOtherLinkerFlags = {
     'add should add the flag to each configuration section': function (test) {
-        var flag = 'some/flag';
+        const flag = 'some/flag';
         proj.addToOtherLinkerFlags(flag);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.OTHER_LDFLAGS;
+            const lib = config[ref].buildSettings.OTHER_LDFLAGS;
             test.ok(lib[1].indexOf(flag) > -1);
         }
         test.done();
@@ -51,17 +51,17 @@ exports.addAndRemoveToFromOtherLinkerFlags = {
     'remove should remove from the path to each configuration section': function (
         test
     ) {
-        var flag = 'some/flag';
+        const flag = 'some/flag';
         proj.addToOtherLinkerFlags(flag);
         proj.removeFromOtherLinkerFlags(flag);
-        var config = proj.pbxXCBuildConfigurationSection();
-        for (var ref in config) {
+        const config = proj.pbxXCBuildConfigurationSection();
+        for (const ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||
                 config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
             )
                 continue;
-            var lib = config[ref].buildSettings.OTHER_LDFLAGS;
+            const lib = config[ref].buildSettings.OTHER_LDFLAGS;
             test.ok(lib.length === 1);
             test.ok(lib[0].indexOf(flag) == -1);
         }

--- a/test/OtherLinkerFlags.js
+++ b/test/OtherLinkerFlags.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -20,40 +20,59 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addBuildPhase = {
     'should return a pbxBuildPhase': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXSourcesBuildPhase', 'My build phase');
+        var buildPhase = proj.addBuildPhase(
+            ['file.m'],
+            'PBXSourcesBuildPhase',
+            'My build phase'
+        );
 
         test.ok(typeof buildPhase === 'object');
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxBuildPhase': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXSourcesBuildPhase', 'My build phase');
+        var buildPhase = proj.addBuildPhase(
+            ['file.m'],
+            'PBXSourcesBuildPhase',
+            'My build phase'
+        );
 
         test.ok(buildPhase.uuid);
-        test.done()
+        test.done();
     },
     'should add all files to build phase': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase;
+        var buildPhase = proj.addBuildPhase(
+            ['file.m', 'assets.bundle'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
         for (var index = 0; index < buildPhase.files.length; index++) {
             var file = buildPhase.files[index];
             test.ok(file.value);
         }
 
-        test.done()
+        test.done();
     },
     'should add the PBXBuildPhase object correctly': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
-            buildPhaseInPbx = proj.buildPhaseObject('PBXResourcesBuildPhase', 'My build phase');
+        var buildPhase = proj.addBuildPhase(
+                ['file.m', 'assets.bundle'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
+            buildPhaseInPbx = proj.buildPhaseObject(
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            );
 
         test.equal(buildPhaseInPbx, buildPhase);
         test.equal(buildPhaseInPbx.isa, 'PBXResourcesBuildPhase');
@@ -62,7 +81,11 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add each of the files to PBXBuildFile section': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
+        var buildPhase = proj.addBuildPhase(
+                ['file.m', 'assets.bundle'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
             buildFileSection = proj.pbxBuildFileSection();
 
         for (var index = 0; index < buildPhase.files.length; index++) {
@@ -72,8 +95,14 @@ exports.addBuildPhase = {
 
         test.done();
     },
-    'should add each of the files to PBXFileReference section': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
+    'should add each of the files to PBXFileReference section': function (
+        test
+    ) {
+        var buildPhase = proj.addBuildPhase(
+                ['file.m', 'assets.bundle'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
             fileRefSection = proj.pbxFileReferenceSection(),
             buildFileSection = proj.pbxBuildFileSection(),
             fileRefs = [];
@@ -87,30 +116,64 @@ exports.addBuildPhase = {
 
         test.done();
     },
-    'should not add files to PBXFileReference section if already added': function (test) {
+    'should not add files to PBXFileReference section if already added': function (
+        test
+    ) {
         var fileRefSection = proj.pbxFileReferenceSection(),
-            initialFileReferenceSectionItemsCount = Object.keys(fileRefSection),
-            buildPhase = proj.addBuildPhase(['AppDelegate.m', 'main.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(fileRefSection);
+            initialFileReferenceSectionItemsCount = Object.keys(
+                fileRefSection
+            ),
+            buildPhase = proj.addBuildPhase(
+                ['AppDelegate.m', 'main.m'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                fileRefSection
+            );
 
-        test.deepEqual(initialFileReferenceSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialFileReferenceSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should not add files to PBXBuildFile section if already added': function (test) {
-        var buildFileSection  = proj.pbxBuildFileSection(),
-            initialBuildFileSectionItemsCount  = Object.keys(buildFileSection),
-            buildPhase = proj.addBuildPhase(['AppDelegate.m', 'main.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+    'should not add files to PBXBuildFile section if already added': function (
+        test
+    ) {
+        var buildFileSection = proj.pbxBuildFileSection(),
+            initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
+            buildPhase = proj.addBuildPhase(
+                ['AppDelegate.m', 'main.m'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                buildFileSection
+            );
 
-        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialBuildFileSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should add only missing files to PBXFileReference section': function (test) {
+    'should add only missing files to PBXFileReference section': function (
+        test
+    ) {
         var fileRefSection = proj.pbxFileReferenceSection(),
             buildFileSection = proj.pbxBuildFileSection(),
-            initialFileReferenceSectionItemsCount = Object.keys(fileRefSection),
-            buildPhase = proj.addBuildPhase(['file.m', 'AppDelegate.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(fileRefSection);
+            initialFileReferenceSectionItemsCount = Object.keys(
+                fileRefSection
+            ),
+            buildPhase = proj.addBuildPhase(
+                ['file.m', 'AppDelegate.m'],
+                'PBXResourcesBuildPhase',
+                'My build phase'
+            ).buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                fileRefSection
+            );
 
         for (var index = 0; index < buildPhase.files.length; index++) {
             var file = buildPhase.files[index],
@@ -119,19 +182,39 @@ exports.addBuildPhase = {
             test.ok(fileRefSection[fileRef]);
         }
 
-        test.deepEqual(initialFileReferenceSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 2);
+        test.deepEqual(
+            initialFileReferenceSectionItemsCount.length,
+            afterAdditionBuildFileSectionItemsCount.length - 2
+        );
         test.done();
     },
-    'should set target to Frameworks given \'frameworks\' as target': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid, 'frameworks').buildPhase;
+    "should set target to Frameworks given 'frameworks' as target": function (
+        test
+    ) {
+        var buildPhase = proj.addBuildPhase(
+            ['file.m'],
+            'PBXCopyFilesBuildPhase',
+            'Copy Files',
+            proj.getFirstTarget().uuid,
+            'frameworks'
+        ).buildPhase;
         test.equal(buildPhase.dstSubfolderSpec, 10);
         test.done();
     },
-    'should add a script build phase to echo "hello world!"': function(test) {
-        var options = {shellPath: '/bin/sh', shellScript: 'echo "hello world!"'};
-        var buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+    'should add a script build phase to echo "hello world!"': function (test) {
+        var options = {
+            shellPath: '/bin/sh',
+            shellScript: 'echo "hello world!"'
+        };
+        var buildPhase = proj.addBuildPhase(
+            [],
+            'PBXShellScriptBuildPhase',
+            'Run a script',
+            proj.getFirstTarget().uuid,
+            options
+        ).buildPhase;
         test.equal(buildPhase.shellPath, '/bin/sh');
         test.equal(buildPhase.shellScript, '"echo \\"hello world!\\""');
         test.done();
-    },
-}
+    }
+};

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,7 +31,7 @@ exports.setUp = function (callback) {
 
 exports.addBuildPhase = {
     'should return a pbxBuildPhase': function (test) {
-        var buildPhase = proj.addBuildPhase(
+        const buildPhase = proj.addBuildPhase(
             ['file.m'],
             'PBXSourcesBuildPhase',
             'My build phase'
@@ -41,7 +41,7 @@ exports.addBuildPhase = {
         test.done();
     },
     'should set a uuid on the pbxBuildPhase': function (test) {
-        var buildPhase = proj.addBuildPhase(
+        const buildPhase = proj.addBuildPhase(
             ['file.m'],
             'PBXSourcesBuildPhase',
             'My build phase'
@@ -51,28 +51,28 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add all files to build phase': function (test) {
-        var buildPhase = proj.addBuildPhase(
+        const buildPhase = proj.addBuildPhase(
             ['file.m', 'assets.bundle'],
             'PBXResourcesBuildPhase',
             'My build phase'
         ).buildPhase;
-        for (var index = 0; index < buildPhase.files.length; index++) {
-            var file = buildPhase.files[index];
+        for (let index = 0; index < buildPhase.files.length; index++) {
+            const file = buildPhase.files[index];
             test.ok(file.value);
         }
 
         test.done();
     },
     'should add the PBXBuildPhase object correctly': function (test) {
-        var buildPhase = proj.addBuildPhase(
-                ['file.m', 'assets.bundle'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            buildPhaseInPbx = proj.buildPhaseObject(
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            );
+        const buildPhase = proj.addBuildPhase(
+            ['file.m', 'assets.bundle'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const buildPhaseInPbx = proj.buildPhaseObject(
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        );
 
         test.equal(buildPhaseInPbx, buildPhase);
         test.equal(buildPhaseInPbx.isa, 'PBXResourcesBuildPhase');
@@ -81,15 +81,15 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add each of the files to PBXBuildFile section': function (test) {
-        var buildPhase = proj.addBuildPhase(
-                ['file.m', 'assets.bundle'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            buildFileSection = proj.pbxBuildFileSection();
+        const buildPhase = proj.addBuildPhase(
+            ['file.m', 'assets.bundle'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const buildFileSection = proj.pbxBuildFileSection();
 
-        for (var index = 0; index < buildPhase.files.length; index++) {
-            var file = buildPhase.files[index];
+        for (let index = 0; index < buildPhase.files.length; index++) {
+            const file = buildPhase.files[index];
             test.ok(buildFileSection[file.value]);
         }
 
@@ -98,18 +98,18 @@ exports.addBuildPhase = {
     'should add each of the files to PBXFileReference section': function (
         test
     ) {
-        var buildPhase = proj.addBuildPhase(
-                ['file.m', 'assets.bundle'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            fileRefSection = proj.pbxFileReferenceSection(),
-            buildFileSection = proj.pbxBuildFileSection(),
-            fileRefs = [];
+        const buildPhase = proj.addBuildPhase(
+            ['file.m', 'assets.bundle'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const buildFileSection = proj.pbxBuildFileSection();
+        const fileRefs = [];
 
-        for (var index = 0; index < buildPhase.files.length; index++) {
-            var file = buildPhase.files[index],
-                fileRef = buildFileSection[file.value].fileRef;
+        for (let index = 0; index < buildPhase.files.length; index++) {
+            const file = buildPhase.files[index];
+            const fileRef = buildFileSection[file.value].fileRef;
 
             test.ok(fileRefSection[fileRef]);
         }
@@ -119,18 +119,18 @@ exports.addBuildPhase = {
     'should not add files to PBXFileReference section if already added': function (
         test
     ) {
-        var fileRefSection = proj.pbxFileReferenceSection(),
-            initialFileReferenceSectionItemsCount = Object.keys(
-                fileRefSection
-            ),
-            buildPhase = proj.addBuildPhase(
-                ['AppDelegate.m', 'main.m'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                fileRefSection
-            );
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const initialFileReferenceSectionItemsCount = Object.keys(
+            fileRefSection
+        );
+        const buildPhase = proj.addBuildPhase(
+            ['AppDelegate.m', 'main.m'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            fileRefSection
+        );
 
         test.deepEqual(
             initialFileReferenceSectionItemsCount,
@@ -141,16 +141,16 @@ exports.addBuildPhase = {
     'should not add files to PBXBuildFile section if already added': function (
         test
     ) {
-        var buildFileSection = proj.pbxBuildFileSection(),
-            initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            buildPhase = proj.addBuildPhase(
-                ['AppDelegate.m', 'main.m'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                buildFileSection
-            );
+        const buildFileSection = proj.pbxBuildFileSection();
+        const initialBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        const buildPhase = proj.addBuildPhase(
+            ['AppDelegate.m', 'main.m'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            buildFileSection
+        );
 
         test.deepEqual(
             initialBuildFileSectionItemsCount,
@@ -161,23 +161,23 @@ exports.addBuildPhase = {
     'should add only missing files to PBXFileReference section': function (
         test
     ) {
-        var fileRefSection = proj.pbxFileReferenceSection(),
-            buildFileSection = proj.pbxBuildFileSection(),
-            initialFileReferenceSectionItemsCount = Object.keys(
-                fileRefSection
-            ),
-            buildPhase = proj.addBuildPhase(
-                ['file.m', 'AppDelegate.m'],
-                'PBXResourcesBuildPhase',
-                'My build phase'
-            ).buildPhase,
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                fileRefSection
-            );
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const buildFileSection = proj.pbxBuildFileSection();
+        const initialFileReferenceSectionItemsCount = Object.keys(
+            fileRefSection
+        );
+        const buildPhase = proj.addBuildPhase(
+            ['file.m', 'AppDelegate.m'],
+            'PBXResourcesBuildPhase',
+            'My build phase'
+        ).buildPhase;
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            fileRefSection
+        );
 
-        for (var index = 0; index < buildPhase.files.length; index++) {
-            var file = buildPhase.files[index],
-                fileRef = buildFileSection[file.value].fileRef;
+        for (let index = 0; index < buildPhase.files.length; index++) {
+            const file = buildPhase.files[index];
+            const fileRef = buildFileSection[file.value].fileRef;
 
             test.ok(fileRefSection[fileRef]);
         }
@@ -191,7 +191,7 @@ exports.addBuildPhase = {
     "should set target to Frameworks given 'frameworks' as target": function (
         test
     ) {
-        var buildPhase = proj.addBuildPhase(
+        const buildPhase = proj.addBuildPhase(
             ['file.m'],
             'PBXCopyFilesBuildPhase',
             'Copy Files',
@@ -202,11 +202,11 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add a script build phase to echo "hello world!"': function (test) {
-        var options = {
+        const options = {
             shellPath: '/bin/sh',
             shellScript: 'echo "hello world!"'
         };
-        var buildPhase = proj.addBuildPhase(
+        const buildPhase = proj.addBuildPhase(
             [],
             'PBXShellScriptBuildPhase',
             'Run a script',

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,9 +31,9 @@ exports.setUp = function (callback) {
 };
 
 function nonComments (obj) {
-    var keys = Object.keys(obj),
-        newObj = {},
-        i = 0;
+    const keys = Object.keys(obj);
+    const newObj = {};
+    let i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -45,11 +45,11 @@ function nonComments (obj) {
 }
 
 function frameworkSearchPaths (proj) {
-    var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
-        allPaths = [],
-        ids = Object.keys(configs),
-        i,
-        buildSettings;
+    const configs = nonComments(proj.pbxXCBuildConfigurationSection());
+    const allPaths = [];
+    const ids = Object.keys(configs);
+    let i;
+    let buildSettings;
 
     for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
@@ -64,13 +64,13 @@ function frameworkSearchPaths (proj) {
 
 exports.addFramework = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
 
         test.ok(newFile.fileRef);
         test.done();
@@ -78,7 +78,7 @@ exports.addFramework = {
     'should populate the PBXFileReference section with 2 fields': function (
         test
     ) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
         (fileRefSection = proj.pbxFileReferenceSection()),
         (frsLength = Object.keys(fileRefSection).length);
 
@@ -89,7 +89,7 @@ exports.addFramework = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
         (fileRefSection = proj.pbxFileReferenceSection()),
         (commentKey = newFile.fileRef + '_comment');
 
@@ -97,9 +97,9 @@ exports.addFramework = {
         test.done();
     },
     'should add the PBXFileReference object correctly': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.lastKnownFileType, 'compiled.mach-o.dylib');
@@ -110,9 +110,9 @@ exports.addFramework = {
         test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -121,9 +121,9 @@ exports.addFramework = {
         test.done();
     },
     'should add the PBXBuildFile comment correctly': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const commentKey = newFile.uuid + '_comment';
+        const buildFileSection = proj.pbxBuildFileSection();
 
         test.equal(
             buildFileSection[commentKey],
@@ -132,9 +132,9 @@ exports.addFramework = {
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
@@ -146,9 +146,9 @@ exports.addFramework = {
     'should add the PBXBuildFile object correctly /w weak linked frameworks': function (
         test
     ) {
-        var newFile = proj.addFramework('libsqlite3.dylib', { weak: true }),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addFramework('libsqlite3.dylib', { weak: true });
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
@@ -158,40 +158,40 @@ exports.addFramework = {
         test.done();
     },
     'should add to the Frameworks PBXGroup': function (test) {
-        var newLength = proj.pbxGroupByName('Frameworks').children.length + 1,
-            newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxGroupByName('Frameworks');
+        const newLength = proj.pbxGroupByName('Frameworks').children.length + 1;
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const frameworks = proj.pbxGroupByName('Frameworks');
 
         test.equal(frameworks.children.length, newLength);
         test.done();
     },
     'should have the right values for the PBXGroup entry': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxGroupByName('Frameworks').children,
-            framework = frameworks[frameworks.length - 1];
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const frameworks = proj.pbxGroupByName('Frameworks').children;
+        const framework = frameworks[frameworks.length - 1];
 
         test.equal(framework.comment, 'libsqlite3.dylib');
         test.equal(framework.value, newFile.fileRef);
         test.done();
     },
     'should add to the PBXFrameworksBuildPhase': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
         test.done();
     },
     'should not add to the PBXFrameworksBuildPhase': function (test) {
-        var newFile = proj.addFramework('Private.framework', { link: false }),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework('Private.framework', { link: false });
+        const frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj(),
-            framework = frameworks.files[15];
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const framework = frameworks.files[15];
 
         test.equal(framework.comment, 'libsqlite3.dylib in Frameworks');
         test.equal(framework.value, newFile.uuid);
@@ -199,14 +199,14 @@ exports.addFramework = {
     },
     'duplicate entries': {
         'should return false': function (test) {
-            var newFile = proj.addFramework('libsqlite3.dylib');
+            const newFile = proj.addFramework('libsqlite3.dylib');
 
             test.ok(!proj.addFramework('libsqlite3.dylib'));
             test.done();
         }
     },
     'should pbxFile correctly for custom frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {
+        const newFile = proj.addFramework('/path/to/Custom.framework', {
             customFramework: true
         });
 
@@ -220,11 +220,11 @@ exports.addFramework = {
         test.equal(newFile.path, '/path/to/Custom.framework');
 
         // should add path to framework search path
-        var frameworkPaths = frameworkSearchPaths(proj);
+        const frameworkPaths = frameworkSearchPaths(proj);
         expectedPath = '"\\"/path/to\\""';
 
         for (i = 0; i < frameworkPaths.length; i++) {
-            var current = frameworkPaths[i];
+            const current = frameworkPaths[i];
             test.ok(current.indexOf('"$(inherited)"') >= 0);
             test.ok(current.indexOf(expectedPath) >= 0);
         }
@@ -233,13 +233,13 @@ exports.addFramework = {
     'should add to the Embed Frameworks PBXCopyFilesBuildPhase': function (
         test
     ) {
-        var newFile = proj.addFramework(
-                '/path/to/SomeEmbeddableCustom.framework',
-                { customFramework: true, embed: true }
-            ),
-            frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework(
+            '/path/to/SomeEmbeddableCustom.framework',
+            { customFramework: true, embed: true }
+        );
+        const frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
-        var buildPhaseInPbx = proj.pbxEmbedFrameworksBuildPhaseObj();
+        const buildPhaseInPbx = proj.pbxEmbedFrameworksBuildPhaseObj();
         test.equal(buildPhaseInPbx.dstSubfolderSpec, 10);
 
         test.equal(frameworks.files.length, 1);
@@ -248,10 +248,10 @@ exports.addFramework = {
     'should not add to the Embed Frameworks PBXCopyFilesBuildPhase by default': function (
         test
     ) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {
-                customFramework: true
-            }),
-            frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework('/path/to/Custom.framework', {
+            customFramework: true
+        });
+        const frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 0);
         test.done();
@@ -259,13 +259,13 @@ exports.addFramework = {
     'should add the PBXBuildFile object correctly /w signable frameworks': function (
         test
     ) {
-        var newFile = proj.addFramework('/path/to/SomeSignable.framework', {
-                customFramework: true,
-                embed: true,
-                sign: true
-            }),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addFramework('/path/to/SomeSignable.framework', {
+            customFramework: true,
+            embed: true,
+            sign: true
+        });
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(newFile.group, 'Embed Frameworks');
         test.equal(buildFileEntry.isa, 'PBXBuildFile');

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -21,18 +21,19 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
-function nonComments(obj) {
+function nonComments (obj) {
     var keys = Object.keys(obj),
-        newObj = {}, i = 0;
+        newObj = {},
+        i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -43,12 +44,14 @@ function nonComments(obj) {
     return newObj;
 }
 
-function frameworkSearchPaths(proj) {
+function frameworkSearchPaths (proj) {
     var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
         allPaths = [],
-        ids = Object.keys(configs), i, buildSettings;
+        ids = Object.keys(configs),
+        i,
+        buildSettings;
 
-    for (i = 0; i< ids.length; i++) {
+    for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
 
         if (buildSettings['FRAMEWORK_SEARCH_PATHS']) {
@@ -64,18 +67,20 @@ exports.addFramework = {
         var newFile = proj.addFramework('libsqlite3.dylib');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addFramework('libsqlite3.dylib');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
-    'should populate the PBXFileReference section with 2 fields': function (test) {
+    'should populate the PBXFileReference section with 2 fields': function (
+        test
+    ) {
         var newFile = proj.addFramework('libsqlite3.dylib');
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        (fileRefSection = proj.pbxFileReferenceSection()),
+        (frsLength = Object.keys(fileRefSection).length);
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -85,8 +90,8 @@ exports.addFramework = {
     },
     'should populate the PBXFileReference comment correctly': function (test) {
         var newFile = proj.addFramework('libsqlite3.dylib');
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        (fileRefSection = proj.pbxFileReferenceSection()),
+        (commentKey = newFile.fileRef + '_comment');
 
         test.equal(fileRefSection[commentKey], 'libsqlite3.dylib');
         test.done();
@@ -120,7 +125,10 @@ exports.addFramework = {
             commentKey = newFile.uuid + '_comment',
             buildFileSection = proj.pbxBuildFileSection();
 
-        test.equal(buildFileSection[commentKey], 'libsqlite3.dylib in Frameworks');
+        test.equal(
+            buildFileSection[commentKey],
+            'libsqlite3.dylib in Frameworks'
+        );
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
@@ -135,7 +143,9 @@ exports.addFramework = {
 
         test.done();
     },
-    'should add the PBXBuildFile object correctly /w weak linked frameworks': function (test) {
+    'should add the PBXBuildFile object correctly /w weak linked frameworks': function (
+        test
+    ) {
         var newFile = proj.addFramework('libsqlite3.dylib', { weak: true }),
             buildFileSection = proj.pbxBuildFileSection(),
             buildFileEntry = buildFileSection[newFile.uuid];
@@ -143,7 +153,7 @@ exports.addFramework = {
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
         test.equal(buildFileEntry.fileRef_comment, 'libsqlite3.dylib');
-        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'Weak' ] });
+        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: ['Weak'] });
 
         test.done();
     },
@@ -172,7 +182,7 @@ exports.addFramework = {
         test.done();
     },
     'should not add to the PBXFrameworksBuildPhase': function (test) {
-        var newFile = proj.addFramework('Private.framework', {link: false}),
+        var newFile = proj.addFramework('Private.framework', { link: false }),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
@@ -196,7 +206,9 @@ exports.addFramework = {
         }
     },
     'should pbxFile correctly for custom frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {customFramework: true});
+        var newFile = proj.addFramework('/path/to/Custom.framework', {
+            customFramework: true
+        });
 
         test.ok(newFile.customFramework);
         test.ok(!newFile.fileEncoding);
@@ -207,10 +219,9 @@ exports.addFramework = {
         // XXX framework has to be copied over to PROJECT root. That is what XCode does when you drag&drop
         test.equal(newFile.path, '/path/to/Custom.framework');
 
-
         // should add path to framework search path
         var frameworkPaths = frameworkSearchPaths(proj);
-            expectedPath = '"\\"/path/to\\""';
+        expectedPath = '"\\"/path/to\\""';
 
         for (i = 0; i < frameworkPaths.length; i++) {
             var current = frameworkPaths[i];
@@ -219,8 +230,13 @@ exports.addFramework = {
         }
         test.done();
     },
-    'should add to the Embed Frameworks PBXCopyFilesBuildPhase': function (test) {
-        var newFile = proj.addFramework('/path/to/SomeEmbeddableCustom.framework', {customFramework: true, embed: true}),
+    'should add to the Embed Frameworks PBXCopyFilesBuildPhase': function (
+        test
+    ) {
+        var newFile = proj.addFramework(
+                '/path/to/SomeEmbeddableCustom.framework',
+                { customFramework: true, embed: true }
+            ),
             frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
         var buildPhaseInPbx = proj.pbxEmbedFrameworksBuildPhaseObj();
@@ -229,15 +245,25 @@ exports.addFramework = {
         test.equal(frameworks.files.length, 1);
         test.done();
     },
-    'should not add to the Embed Frameworks PBXCopyFilesBuildPhase by default': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {customFramework: true}),
+    'should not add to the Embed Frameworks PBXCopyFilesBuildPhase by default': function (
+        test
+    ) {
+        var newFile = proj.addFramework('/path/to/Custom.framework', {
+                customFramework: true
+            }),
             frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 0);
         test.done();
     },
-    'should add the PBXBuildFile object correctly /w signable frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/SomeSignable.framework', { customFramework: true, embed: true, sign: true }),
+    'should add the PBXBuildFile object correctly /w signable frameworks': function (
+        test
+    ) {
+        var newFile = proj.addFramework('/path/to/SomeSignable.framework', {
+                customFramework: true,
+                embed: true,
+                sign: true
+            }),
             buildFileSection = proj.pbxBuildFileSection(),
             buildFileEntry = buildFileSection[newFile.uuid];
 
@@ -245,8 +271,10 @@ exports.addFramework = {
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
         test.equal(buildFileEntry.fileRef_comment, 'SomeSignable.framework');
-        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'CodeSignOnCopy' ] });
+        test.deepEqual(buildFileEntry.settings, {
+            ATTRIBUTES: ['CodeSignOnCopy']
+        });
 
         test.done();
-    },
-}
+    }
+};

--- a/test/addHeaderFile.js
+++ b/test/addHeaderFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addHeaderFile.js
+++ b/test/addHeaderFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,13 +32,13 @@ exports.setUp = function (callback) {
 
 exports.addHeaderFile = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addHeaderFile('file.h');
+        const newFile = proj.addHeaderFile('file.h');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addHeaderFile('file.h');
+        const newFile = proj.addHeaderFile('file.h');
 
         test.ok(newFile.fileRef);
         test.done();
@@ -46,9 +46,9 @@ exports.addHeaderFile = {
     'should populate the PBXFileReference section with 2 fields': function (
         test
     ) {
-        var newFile = proj.addHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addHeaderFile('file.h');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -57,17 +57,17 @@ exports.addHeaderFile = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addHeaderFile('file.h');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const commentKey = newFile.fileRef + '_comment';
 
         test.equal(fileRefSection[commentKey], 'file.h');
         test.done();
     },
     'should add the PBXFileReference object correctly': function (test) {
-        var newFile = proj.addHeaderFile('Plugins/file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addHeaderFile('Plugins/file.h');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, 4);
@@ -79,16 +79,16 @@ exports.addHeaderFile = {
         test.done();
     },
     'should add to the Plugins PBXGroup group': function (test) {
-        var newFile = proj.addHeaderFile('Plugins/file.h'),
-            plugins = proj.pbxGroupByName('Plugins');
+        const newFile = proj.addHeaderFile('Plugins/file.h');
+        const plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 1);
         test.done();
     },
     'should have the right values for the PBXGroup entry': function (test) {
-        var newFile = proj.addHeaderFile('Plugins/file.h'),
-            plugins = proj.pbxGroupByName('Plugins'),
-            pluginObj = plugins.children[0];
+        const newFile = proj.addHeaderFile('Plugins/file.h');
+        const plugins = proj.pbxGroupByName('Plugins');
+        const pluginObj = plugins.children[0];
 
         test.equal(pluginObj.comment, 'file.h');
         test.equal(pluginObj.value, newFile.fileRef);
@@ -96,16 +96,16 @@ exports.addHeaderFile = {
     },
     'duplicate entries': {
         'should return false': function (test) {
-            var newFile = proj.addHeaderFile('Plugins/file.h');
+            const newFile = proj.addHeaderFile('Plugins/file.h');
 
             test.ok(!proj.addHeaderFile('Plugins/file.h'));
             test.done();
         },
         'should not add another entry anywhere': function (test) {
-            var newFile = proj.addHeaderFile('Plugins/file.h'),
-                fileRefSection = proj.pbxFileReferenceSection(),
-                frsLength = Object.keys(fileRefSection).length,
-                plugins = proj.pbxGroupByName('Plugins');
+            const newFile = proj.addHeaderFile('Plugins/file.h');
+            const fileRefSection = proj.pbxFileReferenceSection();
+            const frsLength = Object.keys(fileRefSection).length;
+            const plugins = proj.pbxGroupByName('Plugins');
 
             proj.addHeaderFile('Plugins/file.h');
 

--- a/test/addHeaderFile.js
+++ b/test/addHeaderFile.js
@@ -21,29 +21,31 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addHeaderFile = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addHeaderFile('file.h');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addHeaderFile('file.h');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
-    'should populate the PBXFileReference section with 2 fields': function (test) {
+    'should populate the PBXFileReference section with 2 fields': function (
+        test
+    ) {
         var newFile = proj.addHeaderFile('file.h'),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -112,4 +114,4 @@ exports.addHeaderFile = {
             test.done();
         }
     }
-}
+};

--- a/test/addRemovePbxGroup.js
+++ b/test/addRemovePbxGroup.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');

--- a/test/addRemovePbxGroup.js
+++ b/test/addRemovePbxGroup.js
@@ -20,40 +20,67 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addRemovePbxGroup = {
     'should return a pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application', 'Application', '"<group>"');
+        var pbxGroup = proj.addPbxGroup(
+            ['file.m'],
+            'MyGroup',
+            'Application',
+            'Application',
+            '"<group>"'
+        );
 
         test.ok(typeof pbxGroup === 'object');
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application', 'Application', '"<group>"');
+        var pbxGroup = proj.addPbxGroup(
+            ['file.m'],
+            'MyGroup',
+            'Application',
+            'Application',
+            '"<group>"'
+        );
 
         test.ok(pbxGroup.uuid);
-        test.done()
+        test.done();
     },
     'should add all files to pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application', 'Application', '"<group>"');
-        for (var index = 0; index < pbxGroup.pbxGroup.children.length; index++) {
+        var pbxGroup = proj.addPbxGroup(
+            ['file.m'],
+            'MyGroup',
+            'Application',
+            'Application',
+            '"<group>"'
+        );
+        for (
+            var index = 0;
+            index < pbxGroup.pbxGroup.children.length;
+            index++
+        ) {
             var file = pbxGroup.pbxGroup.children[index];
             test.ok(file.value);
         }
 
-        test.done()
+        test.done();
     },
     'should add the PBXGroup object correctly': function (test) {
-        var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application', '"<group>"');
-            pbxGroupInPbx = proj.pbxGroupByName('MyGroup');
+        var pbxGroup = proj.addPbxGroup(
+            ['file.m'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        pbxGroupInPbx = proj.pbxGroupByName('MyGroup');
 
         test.equal(pbxGroupInPbx.children, pbxGroup.pbxGroup.children);
         test.equal(pbxGroupInPbx.isa, 'PBXGroup');
@@ -63,7 +90,7 @@ exports.addRemovePbxGroup = {
     },
     'should add <group> sourceTree if no other specified': function (test) {
         var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application');
-            pbxGroupInPbx = proj.pbxGroupByName('MyGroup');
+        pbxGroupInPbx = proj.pbxGroupByName('MyGroup');
 
         test.equal(pbxGroupInPbx.sourceTree, '"<group>"');
         test.done();
@@ -72,106 +99,217 @@ exports.addRemovePbxGroup = {
         var buildFileSection = proj.pbxBuildFileSection();
         for (var key in buildFileSection) {
             test.notEqual(buildFileSection[key].fileRef_comment, 'file.m');
-            test.notEqual(buildFileSection[key].fileRef_comment, 'assets.bundle');
+            test.notEqual(
+                buildFileSection[key].fileRef_comment,
+                'assets.bundle'
+            );
         }
 
         var initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(['file.m', 'assets.bundle'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+            pbxGroup = proj.addPbxGroup(
+                ['file.m', 'assets.bundle'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                buildFileSection
+            );
 
         // for each file added in the build file section two keyes are added - one for the object and one for the comment
-        test.equal(initialBuildFileSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 4);
+        test.equal(
+            initialBuildFileSectionItemsCount.length,
+            afterAdditionBuildFileSectionItemsCount.length - 4
+        );
         test.done();
     },
-    'should not add any of the files to PBXBuildFile section if already added': function (test) {
+    'should not add any of the files to PBXBuildFile section if already added': function (
+        test
+    ) {
         var buildFileSection = proj.pbxBuildFileSection(),
             initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(['AppDelegate.m', 'AppDelegate.h'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+            pbxGroup = proj.addPbxGroup(
+                ['AppDelegate.m', 'AppDelegate.h'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                buildFileSection
+            );
 
-        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialBuildFileSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should not add any of the files to PBXBuildFile section when they contain special symbols and are already added': function (test) {
+    'should not add any of the files to PBXBuildFile section when they contain special symbols and are already added': function (
+        test
+    ) {
         var buildFileSection = proj.pbxBuildFileSection(),
             initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(['KitchenSinktablet.app'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+            pbxGroup = proj.addPbxGroup(
+                ['KitchenSinktablet.app'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                buildFileSection
+            );
 
-        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialBuildFileSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should add all files which are not added and not add files already added to PBXBuildFile section': function (test) {
+    'should add all files which are not added and not add files already added to PBXBuildFile section': function (
+        test
+    ) {
         var buildFileSection = proj.pbxBuildFileSection();
         for (var key in buildFileSection) {
             test.notEqual(buildFileSection[key].fileRef_comment, 'file.m');
-            test.notEqual(buildFileSection[key].fileRef_comment, 'assets.bundle');
+            test.notEqual(
+                buildFileSection[key].fileRef_comment,
+                'assets.bundle'
+            );
         }
 
         var initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+            pbxGroup = proj.addPbxGroup(
+                ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                buildFileSection
+            );
 
         // for each file added in the build file section two keyes are added - one for the object and one for the comment
-        test.equal(initialBuildFileSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 4);
+        test.equal(
+            initialBuildFileSectionItemsCount.length,
+            afterAdditionBuildFileSectionItemsCount.length - 4
+        );
         test.done();
     },
-    'should add each of the files to PBXFileReference section': function (test) {
+    'should add each of the files to PBXFileReference section': function (
+        test
+    ) {
         var fileReference = proj.pbxFileReferenceSection();
         for (var key in fileReference) {
             test.notEqual(fileReference[key].fileRef_comment, 'file.m');
-            test.notEqual(fileReference[key].fileRef_comment, 'assets.bundle');
+            test.notEqual(
+                fileReference[key].fileRef_comment,
+                'assets.bundle'
+            );
         }
-        var pbxGroup = proj.addPbxGroup(['file.m', 'assets.bundle'], 'MyGroup', 'Application', '"<group>"');
-        for (var index = 0; index < pbxGroup.pbxGroup.children.length; index++) {
+        var pbxGroup = proj.addPbxGroup(
+            ['file.m', 'assets.bundle'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        for (
+            var index = 0;
+            index < pbxGroup.pbxGroup.children.length;
+            index++
+        ) {
             var file = pbxGroup.pbxGroup.children[index];
             test.ok(fileReference[file.value]);
         }
 
         test.done();
     },
-    'should not add any of the files to PBXFileReference section if already added': function (test) {
-        var fileReference = proj.pbxFileReferenceSection (),
+    'should not add any of the files to PBXFileReference section if already added': function (
+        test
+    ) {
+        var fileReference = proj.pbxFileReferenceSection(),
             initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(['AppDelegate.m', 'AppDelegate.h'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(fileReference);
+            pbxGroup = proj.addPbxGroup(
+                ['AppDelegate.m', 'AppDelegate.h'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                fileReference
+            );
 
-        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialBuildFileSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should not add any of the files to PBXFileReference section when they contain special symbols and are already added': function (test) {
-        var fileReference = proj.pbxFileReferenceSection (),
+    'should not add any of the files to PBXFileReference section when they contain special symbols and are already added': function (
+        test
+    ) {
+        var fileReference = proj.pbxFileReferenceSection(),
             initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(['KitchenSinktablet.app'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(fileReference);
+            pbxGroup = proj.addPbxGroup(
+                ['KitchenSinktablet.app'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                fileReference
+            );
 
-        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.deepEqual(
+            initialBuildFileSectionItemsCount,
+            afterAdditionBuildFileSectionItemsCount
+        );
         test.done();
     },
-    'should add all files which are not added and not add files already added to PBXFileReference section': function (test) {
-        var fileReference = proj.pbxFileReferenceSection ();
+    'should add all files which are not added and not add files already added to PBXFileReference section': function (
+        test
+    ) {
+        var fileReference = proj.pbxFileReferenceSection();
         for (var key in fileReference) {
             test.notEqual(fileReference[key].fileRef_comment, 'file.m');
-            test.notEqual(fileReference[key].fileRef_comment, 'assets.bundle');
+            test.notEqual(
+                fileReference[key].fileRef_comment,
+                'assets.bundle'
+            );
         }
 
         var initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'], 'MyGroup', 'Application', '"<group>"'),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(fileReference);
+            pbxGroup = proj.addPbxGroup(
+                ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
+                'MyGroup',
+                'Application',
+                '"<group>"'
+            ),
+            afterAdditionBuildFileSectionItemsCount = Object.keys(
+                fileReference
+            );
 
         // for each file added in the file reference section two keyes are added - one for the object and one for the comment
-        test.equal(initialBuildFileSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 4);
+        test.equal(
+            initialBuildFileSectionItemsCount.length,
+            afterAdditionBuildFileSectionItemsCount.length - 4
+        );
         test.done();
     },
     'should remove a pbxGroup': function (test) {
         var groupName = 'MyGroup';
-        proj.addPbxGroup(['file.m'], groupName, 'Application', 'Application', '"<group>"');
+        proj.addPbxGroup(
+            ['file.m'],
+            groupName,
+            'Application',
+            'Application',
+            '"<group>"'
+        );
         proj.removePbxGroup(groupName);
 
         var pbxGroupInPbx = proj.pbxGroupByName(groupName);
         console.log(pbxGroupInPbx);
 
         test.ok(!pbxGroupInPbx);
-        test.done()
+        test.done();
     }
-}
+};

--- a/test/addRemovePbxGroup.js
+++ b/test/addRemovePbxGroup.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,7 +31,7 @@ exports.setUp = function (callback) {
 
 exports.addRemovePbxGroup = {
     'should return a pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(
+        const pbxGroup = proj.addPbxGroup(
             ['file.m'],
             'MyGroup',
             'Application',
@@ -43,7 +43,7 @@ exports.addRemovePbxGroup = {
         test.done();
     },
     'should set a uuid on the pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(
+        const pbxGroup = proj.addPbxGroup(
             ['file.m'],
             'MyGroup',
             'Application',
@@ -55,7 +55,7 @@ exports.addRemovePbxGroup = {
         test.done();
     },
     'should add all files to pbxGroup': function (test) {
-        var pbxGroup = proj.addPbxGroup(
+        const pbxGroup = proj.addPbxGroup(
             ['file.m'],
             'MyGroup',
             'Application',
@@ -63,18 +63,18 @@ exports.addRemovePbxGroup = {
             '"<group>"'
         );
         for (
-            var index = 0;
+            let index = 0;
             index < pbxGroup.pbxGroup.children.length;
             index++
         ) {
-            var file = pbxGroup.pbxGroup.children[index];
+            const file = pbxGroup.pbxGroup.children[index];
             test.ok(file.value);
         }
 
         test.done();
     },
     'should add the PBXGroup object correctly': function (test) {
-        var pbxGroup = proj.addPbxGroup(
+        const pbxGroup = proj.addPbxGroup(
             ['file.m'],
             'MyGroup',
             'Application',
@@ -89,15 +89,15 @@ exports.addRemovePbxGroup = {
         test.done();
     },
     'should add <group> sourceTree if no other specified': function (test) {
-        var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application');
+        const pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application');
         pbxGroupInPbx = proj.pbxGroupByName('MyGroup');
 
         test.equal(pbxGroupInPbx.sourceTree, '"<group>"');
         test.done();
     },
     'should add each of the files to PBXBuildFile section': function (test) {
-        var buildFileSection = proj.pbxBuildFileSection();
-        for (var key in buildFileSection) {
+        const buildFileSection = proj.pbxBuildFileSection();
+        for (const key in buildFileSection) {
             test.notEqual(buildFileSection[key].fileRef_comment, 'file.m');
             test.notEqual(
                 buildFileSection[key].fileRef_comment,
@@ -105,16 +105,16 @@ exports.addRemovePbxGroup = {
             );
         }
 
-        var initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(
-                ['file.m', 'assets.bundle'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                buildFileSection
-            );
+        const initialBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        const pbxGroup = proj.addPbxGroup(
+            ['file.m', 'assets.bundle'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            buildFileSection
+        );
 
         // for each file added in the build file section two keyes are added - one for the object and one for the comment
         test.equal(
@@ -126,17 +126,17 @@ exports.addRemovePbxGroup = {
     'should not add any of the files to PBXBuildFile section if already added': function (
         test
     ) {
-        var buildFileSection = proj.pbxBuildFileSection(),
-            initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(
-                ['AppDelegate.m', 'AppDelegate.h'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                buildFileSection
-            );
+        const buildFileSection = proj.pbxBuildFileSection();
+        const initialBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        const pbxGroup = proj.addPbxGroup(
+            ['AppDelegate.m', 'AppDelegate.h'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            buildFileSection
+        );
 
         test.deepEqual(
             initialBuildFileSectionItemsCount,
@@ -147,17 +147,17 @@ exports.addRemovePbxGroup = {
     'should not add any of the files to PBXBuildFile section when they contain special symbols and are already added': function (
         test
     ) {
-        var buildFileSection = proj.pbxBuildFileSection(),
-            initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(
-                ['KitchenSinktablet.app'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                buildFileSection
-            );
+        const buildFileSection = proj.pbxBuildFileSection();
+        const initialBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        const pbxGroup = proj.addPbxGroup(
+            ['KitchenSinktablet.app'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            buildFileSection
+        );
 
         test.deepEqual(
             initialBuildFileSectionItemsCount,
@@ -168,8 +168,8 @@ exports.addRemovePbxGroup = {
     'should add all files which are not added and not add files already added to PBXBuildFile section': function (
         test
     ) {
-        var buildFileSection = proj.pbxBuildFileSection();
-        for (var key in buildFileSection) {
+        const buildFileSection = proj.pbxBuildFileSection();
+        for (const key in buildFileSection) {
             test.notEqual(buildFileSection[key].fileRef_comment, 'file.m');
             test.notEqual(
                 buildFileSection[key].fileRef_comment,
@@ -177,16 +177,16 @@ exports.addRemovePbxGroup = {
             );
         }
 
-        var initialBuildFileSectionItemsCount = Object.keys(buildFileSection),
-            pbxGroup = proj.addPbxGroup(
-                ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                buildFileSection
-            );
+        const initialBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        const pbxGroup = proj.addPbxGroup(
+            ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            buildFileSection
+        );
 
         // for each file added in the build file section two keyes are added - one for the object and one for the comment
         test.equal(
@@ -198,26 +198,26 @@ exports.addRemovePbxGroup = {
     'should add each of the files to PBXFileReference section': function (
         test
     ) {
-        var fileReference = proj.pbxFileReferenceSection();
-        for (var key in fileReference) {
+        const fileReference = proj.pbxFileReferenceSection();
+        for (const key in fileReference) {
             test.notEqual(fileReference[key].fileRef_comment, 'file.m');
             test.notEqual(
                 fileReference[key].fileRef_comment,
                 'assets.bundle'
             );
         }
-        var pbxGroup = proj.addPbxGroup(
+        const pbxGroup = proj.addPbxGroup(
             ['file.m', 'assets.bundle'],
             'MyGroup',
             'Application',
             '"<group>"'
         );
         for (
-            var index = 0;
+            let index = 0;
             index < pbxGroup.pbxGroup.children.length;
             index++
         ) {
-            var file = pbxGroup.pbxGroup.children[index];
+            const file = pbxGroup.pbxGroup.children[index];
             test.ok(fileReference[file.value]);
         }
 
@@ -226,17 +226,17 @@ exports.addRemovePbxGroup = {
     'should not add any of the files to PBXFileReference section if already added': function (
         test
     ) {
-        var fileReference = proj.pbxFileReferenceSection(),
-            initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(
-                ['AppDelegate.m', 'AppDelegate.h'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                fileReference
-            );
+        const fileReference = proj.pbxFileReferenceSection();
+        const initialBuildFileSectionItemsCount = Object.keys(fileReference);
+        const pbxGroup = proj.addPbxGroup(
+            ['AppDelegate.m', 'AppDelegate.h'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            fileReference
+        );
 
         test.deepEqual(
             initialBuildFileSectionItemsCount,
@@ -247,17 +247,17 @@ exports.addRemovePbxGroup = {
     'should not add any of the files to PBXFileReference section when they contain special symbols and are already added': function (
         test
     ) {
-        var fileReference = proj.pbxFileReferenceSection(),
-            initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(
-                ['KitchenSinktablet.app'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                fileReference
-            );
+        const fileReference = proj.pbxFileReferenceSection();
+        const initialBuildFileSectionItemsCount = Object.keys(fileReference);
+        const pbxGroup = proj.addPbxGroup(
+            ['KitchenSinktablet.app'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            fileReference
+        );
 
         test.deepEqual(
             initialBuildFileSectionItemsCount,
@@ -268,8 +268,8 @@ exports.addRemovePbxGroup = {
     'should add all files which are not added and not add files already added to PBXFileReference section': function (
         test
     ) {
-        var fileReference = proj.pbxFileReferenceSection();
-        for (var key in fileReference) {
+        const fileReference = proj.pbxFileReferenceSection();
+        for (const key in fileReference) {
             test.notEqual(fileReference[key].fileRef_comment, 'file.m');
             test.notEqual(
                 fileReference[key].fileRef_comment,
@@ -277,16 +277,16 @@ exports.addRemovePbxGroup = {
             );
         }
 
-        var initialBuildFileSectionItemsCount = Object.keys(fileReference),
-            pbxGroup = proj.addPbxGroup(
-                ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
-                'MyGroup',
-                'Application',
-                '"<group>"'
-            ),
-            afterAdditionBuildFileSectionItemsCount = Object.keys(
-                fileReference
-            );
+        const initialBuildFileSectionItemsCount = Object.keys(fileReference);
+        const pbxGroup = proj.addPbxGroup(
+            ['AppDelegate.m', 'AppDelegate.h', 'file.m', 'assets.bundle'],
+            'MyGroup',
+            'Application',
+            '"<group>"'
+        );
+        const afterAdditionBuildFileSectionItemsCount = Object.keys(
+            fileReference
+        );
 
         // for each file added in the file reference section two keyes are added - one for the object and one for the comment
         test.equal(
@@ -296,7 +296,7 @@ exports.addRemovePbxGroup = {
         test.done();
     },
     'should remove a pbxGroup': function (test) {
-        var groupName = 'MyGroup';
+        const groupName = 'MyGroup';
         proj.addPbxGroup(
             ['file.m'],
             groupName,
@@ -306,7 +306,7 @@ exports.addRemovePbxGroup = {
         );
         proj.removePbxGroup(groupName);
 
-        var pbxGroupInPbx = proj.pbxGroupByName(groupName);
+        const pbxGroupInPbx = proj.pbxGroupByName(groupName);
         console.log(pbxGroupInPbx);
 
         test.ok(!pbxGroupInPbx);

--- a/test/addResourceFile.js
+++ b/test/addResourceFile.js
@@ -21,33 +21,33 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addResourceFile = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addResourceFile('assets.bundle');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         var newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.uuid);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
         var newFile = proj.addResourceFile('assets.bundle'),
@@ -65,7 +65,10 @@ exports.addResourceFile = {
             commentKey = newFile.uuid + '_comment',
             buildFileSection = proj.pbxBuildFileSection();
 
-        test.equal(buildFileSection[commentKey], 'assets.bundle in Resources');
+        test.equal(
+            buildFileSection[commentKey],
+            'assets.bundle in Resources'
+        );
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
@@ -79,7 +82,9 @@ exports.addResourceFile = {
 
         test.done();
     },
-    'should populate the PBXFileReference section with 2 fields': function (test) {
+    'should populate the PBXFileReference section with 2 fields': function (
+        test
+    ) {
         var newFile = proj.addResourceFile('assets.bundle'),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -146,7 +151,9 @@ exports.addResourceFile = {
         test.equal(sourceObj.value, newFile.uuid);
         test.done();
     },
-    'should remove "Resources/" from path if group path is set': function (test) {
+    'should remove "Resources/" from path if group path is set': function (
+        test
+    ) {
         var resources = proj.pbxGroupByName('Resources'),
             newFile;
 
@@ -157,12 +164,14 @@ exports.addResourceFile = {
         test.done();
     },
     'when added with { plugin: true }': {
-
-        'should add the PBXFileReference with the "Plugins" path': function (test) {
+        'should add the PBXFileReference with the "Plugins" path': function (
+            test
+        ) {
             delete proj.pbxGroupByName('Plugins').path;
 
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }),
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                }),
                 fileRefSection = proj.pbxFileReferenceSection(),
                 fileRefEntry = fileRefSection[newFile.fileRef];
 
@@ -176,17 +185,21 @@ exports.addResourceFile = {
         },
 
         'should add to the Plugins PBXGroup group': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }),
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                }),
                 plugins = proj.pbxGroupByName('Plugins');
 
             test.equal(plugins.children.length, 1);
             test.done();
         },
 
-        'should have the Plugins values for the PBXGroup entry': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }),
+        'should have the Plugins values for the PBXGroup entry': function (
+            test
+        ) {
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                }),
                 plugins = proj.pbxGroupByName('Plugins'),
                 pluginObj = plugins.children[0];
 
@@ -196,8 +209,9 @@ exports.addResourceFile = {
         },
 
         'should add to the PBXSourcesBuildPhase': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }),
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                }),
                 sources = proj.pbxResourcesBuildPhaseObj();
 
             test.equal(sources.files.length, 13);
@@ -205,8 +219,9 @@ exports.addResourceFile = {
         },
 
         'should have the right values for the Sources entry': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }),
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                }),
                 sources = proj.pbxResourcesBuildPhaseObj(),
                 sourceObj = sources.files[12];
 
@@ -215,23 +230,29 @@ exports.addResourceFile = {
             test.done();
         },
 
-        'should remove "Plugins/" from path if group path is set': function (test) {
+        'should remove "Plugins/" from path if group path is set': function (
+            test
+        ) {
             var plugins = proj.pbxGroupByName('Plugins'),
                 newFile;
 
             plugins.path = '"Test200/Plugins"';
-            newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                            { plugin: true });
+            newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
 
             test.equal(newFile.path, 'assets.bundle');
             test.done();
         }
     },
     'when added with { variantGroup: true }': {
-
-        'should not add to the PBXResourcesBuildPhase and PBXBuildFile': function (test) {
-            var newFile = proj.addResourceFile('en.lproj/Localization.strings',
-                { variantGroup: true });
+        'should not add to the PBXResourcesBuildPhase and PBXBuildFile': function (
+            test
+        ) {
+            var newFile = proj.addResourceFile(
+                'en.lproj/Localization.strings',
+                { variantGroup: true }
+            );
 
             var sources = proj.pbxResourcesBuildPhaseObj();
             test.equal(sources.files.length, 12);
@@ -240,8 +261,7 @@ exports.addResourceFile = {
             test.ok(buildFileSection[newFile.uuid] === undefined);
 
             test.done();
-        },
-
+        }
     },
     'duplicate entries': {
         'should return false': function (test) {
@@ -251,11 +271,15 @@ exports.addResourceFile = {
             test.done();
         },
         'should return false (plugin entries)': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true });
+            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
 
-            test.ok(!proj.addResourceFile('Plugins/assets.bundle',
-                                                { plugin: true }));
+            test.ok(
+                !proj.addResourceFile('Plugins/assets.bundle', {
+                    plugin: true
+                })
+            );
             test.done();
         },
         'should not add another entry anywhere': function (test) {
@@ -281,4 +305,4 @@ exports.addResourceFile = {
         delete proj.pbxGroupByName('Resources').path;
         callback();
     }
-}
+};

--- a/test/addResourceFile.js
+++ b/test/addResourceFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addResourceFile.js
+++ b/test/addResourceFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,27 +32,27 @@ exports.setUp = function (callback) {
 
 exports.addResourceFile = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.uuid);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.fileRef);
         test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addResourceFile('assets.bundle');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -61,9 +61,9 @@ exports.addResourceFile = {
         test.done();
     },
     'should add the PBXBuildFile comment correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const newFile = proj.addResourceFile('assets.bundle');
+        const commentKey = newFile.uuid + '_comment';
+        const buildFileSection = proj.pbxBuildFileSection();
 
         test.equal(
             buildFileSection[commentKey],
@@ -72,9 +72,9 @@ exports.addResourceFile = {
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addResourceFile('assets.bundle');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
@@ -85,9 +85,9 @@ exports.addResourceFile = {
     'should populate the PBXFileReference section with 2 fields': function (
         test
     ) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addResourceFile('assets.bundle');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -96,9 +96,9 @@ exports.addResourceFile = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addResourceFile('assets.bundle');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const commentKey = newFile.fileRef + '_comment';
 
         test.equal(fileRefSection[commentKey], 'assets.bundle');
         test.done();
@@ -106,9 +106,9 @@ exports.addResourceFile = {
     'should add the PBXFileReference object correctly': function (test) {
         delete proj.pbxGroupByName('Resources').path;
 
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
@@ -120,32 +120,32 @@ exports.addResourceFile = {
         test.done();
     },
     'should add to the Resources PBXGroup group': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            resources = proj.pbxGroupByName('Resources');
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        const resources = proj.pbxGroupByName('Resources');
 
         test.equal(resources.children.length, 10);
         test.done();
     },
     'should have the right values for the PBXGroup entry': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            resources = proj.pbxGroupByName('Resources'),
-            resourceObj = resources.children[9];
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        const resources = proj.pbxGroupByName('Resources');
+        const resourceObj = resources.children[9];
 
         test.equal(resourceObj.comment, 'assets.bundle');
         test.equal(resourceObj.value, newFile.fileRef);
         test.done();
     },
     'should add to the PBXSourcesBuildPhase': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            sources = proj.pbxResourcesBuildPhaseObj();
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        const sources = proj.pbxResourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 13);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            sources = proj.pbxResourcesBuildPhaseObj(),
-            sourceObj = sources.files[12];
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        const sources = proj.pbxResourcesBuildPhaseObj();
+        const sourceObj = sources.files[12];
 
         test.equal(sourceObj.comment, 'assets.bundle in Resources');
         test.equal(sourceObj.value, newFile.uuid);
@@ -154,11 +154,11 @@ exports.addResourceFile = {
     'should remove "Resources/" from path if group path is set': function (
         test
     ) {
-        var resources = proj.pbxGroupByName('Resources'),
-            newFile;
+        const resources = proj.pbxGroupByName('Resources');
 
         resources.path = '"Test200/Resources"';
-        newFile = proj.addResourceFile('Resources/assets.bundle');
+
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
 
         test.equal(newFile.path, 'assets.bundle');
         test.done();
@@ -169,11 +169,11 @@ exports.addResourceFile = {
         ) {
             delete proj.pbxGroupByName('Plugins').path;
 
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
-                    plugin: true
-                }),
-                fileRefSection = proj.pbxFileReferenceSection(),
-                fileRefEntry = fileRefSection[newFile.fileRef];
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
+            const fileRefSection = proj.pbxFileReferenceSection();
+            const fileRefEntry = fileRefSection[newFile.fileRef];
 
             test.equal(fileRefEntry.isa, 'PBXFileReference');
             test.equal(fileRefEntry.fileEncoding, undefined);
@@ -185,10 +185,10 @@ exports.addResourceFile = {
         },
 
         'should add to the Plugins PBXGroup group': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
-                    plugin: true
-                }),
-                plugins = proj.pbxGroupByName('Plugins');
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
+            const plugins = proj.pbxGroupByName('Plugins');
 
             test.equal(plugins.children.length, 1);
             test.done();
@@ -197,11 +197,11 @@ exports.addResourceFile = {
         'should have the Plugins values for the PBXGroup entry': function (
             test
         ) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
-                    plugin: true
-                }),
-                plugins = proj.pbxGroupByName('Plugins'),
-                pluginObj = plugins.children[0];
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
+            const plugins = proj.pbxGroupByName('Plugins');
+            const pluginObj = plugins.children[0];
 
             test.equal(pluginObj.comment, 'assets.bundle');
             test.equal(pluginObj.value, newFile.fileRef);
@@ -209,21 +209,21 @@ exports.addResourceFile = {
         },
 
         'should add to the PBXSourcesBuildPhase': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
-                    plugin: true
-                }),
-                sources = proj.pbxResourcesBuildPhaseObj();
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
+            const sources = proj.pbxResourcesBuildPhaseObj();
 
             test.equal(sources.files.length, 13);
             test.done();
         },
 
         'should have the right values for the Sources entry': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
-                    plugin: true
-                }),
-                sources = proj.pbxResourcesBuildPhaseObj(),
-                sourceObj = sources.files[12];
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
+                plugin: true
+            });
+            const sources = proj.pbxResourcesBuildPhaseObj();
+            const sourceObj = sources.files[12];
 
             test.equal(sourceObj.comment, 'assets.bundle in Resources');
             test.equal(sourceObj.value, newFile.uuid);
@@ -233,11 +233,11 @@ exports.addResourceFile = {
         'should remove "Plugins/" from path if group path is set': function (
             test
         ) {
-            var plugins = proj.pbxGroupByName('Plugins'),
-                newFile;
+            const plugins = proj.pbxGroupByName('Plugins');
 
             plugins.path = '"Test200/Plugins"';
-            newFile = proj.addResourceFile('Plugins/assets.bundle', {
+
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
                 plugin: true
             });
 
@@ -249,15 +249,15 @@ exports.addResourceFile = {
         'should not add to the PBXResourcesBuildPhase and PBXBuildFile': function (
             test
         ) {
-            var newFile = proj.addResourceFile(
+            const newFile = proj.addResourceFile(
                 'en.lproj/Localization.strings',
                 { variantGroup: true }
             );
 
-            var sources = proj.pbxResourcesBuildPhaseObj();
+            const sources = proj.pbxResourcesBuildPhaseObj();
             test.equal(sources.files.length, 12);
 
-            var buildFileSection = proj.pbxBuildFileSection();
+            const buildFileSection = proj.pbxBuildFileSection();
             test.ok(buildFileSection[newFile.uuid] === undefined);
 
             test.done();
@@ -265,13 +265,13 @@ exports.addResourceFile = {
     },
     'duplicate entries': {
         'should return false': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle');
+            const newFile = proj.addResourceFile('Plugins/assets.bundle');
 
             test.ok(!proj.addResourceFile('Plugins/assets.bundle'));
             test.done();
         },
         'should return false (plugin entries)': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle', {
+            const newFile = proj.addResourceFile('Plugins/assets.bundle', {
                 plugin: true
             });
 
@@ -283,13 +283,13 @@ exports.addResourceFile = {
             test.done();
         },
         'should not add another entry anywhere': function (test) {
-            var newFile = proj.addResourceFile('Plugins/assets.bundle'),
-                buildFileSection = proj.pbxBuildFileSection(),
-                bfsLength = Object.keys(buildFileSection).length,
-                fileRefSection = proj.pbxFileReferenceSection(),
-                frsLength = Object.keys(fileRefSection).length,
-                resources = proj.pbxGroupByName('Resources'),
-                sources = proj.pbxResourcesBuildPhaseObj();
+            const newFile = proj.addResourceFile('Plugins/assets.bundle');
+            const buildFileSection = proj.pbxBuildFileSection();
+            const bfsLength = Object.keys(buildFileSection).length;
+            const fileRefSection = proj.pbxFileReferenceSection();
+            const frsLength = Object.keys(fileRefSection).length;
+            const resources = proj.pbxGroupByName('Resources');
+            const sources = proj.pbxResourcesBuildPhaseObj();
 
             proj.addResourceFile('Plugins/assets.bundle');
 

--- a/test/addSourceFile.js
+++ b/test/addSourceFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addSourceFile.js
+++ b/test/addSourceFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,27 +32,27 @@ exports.setUp = function (callback) {
 
 exports.addSourceFile = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addSourceFile('file.m');
+        const newFile = proj.addSourceFile('file.m');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
-        var newFile = proj.addSourceFile('file.m');
+        const newFile = proj.addSourceFile('file.m');
 
         test.ok(newFile.uuid);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addSourceFile('file.m');
+        const newFile = proj.addSourceFile('file.m');
 
         test.ok(newFile.fileRef);
         test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
-        var newFile = proj.addSourceFile('file.m'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addSourceFile('file.m');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -61,17 +61,17 @@ exports.addSourceFile = {
         test.done();
     },
     'should add the PBXBuildFile comment correctly': function (test) {
-        var newFile = proj.addSourceFile('file.m'),
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const newFile = proj.addSourceFile('file.m');
+        const commentKey = newFile.uuid + '_comment';
+        const buildFileSection = proj.pbxBuildFileSection();
 
         test.equal(buildFileSection[commentKey], 'file.m in Sources');
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
-        var newFile = proj.addSourceFile('file.m'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addSourceFile('file.m');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
@@ -82,9 +82,9 @@ exports.addSourceFile = {
     'should populate the PBXFileReference section with 2 fields': function (
         test
     ) {
-        var newFile = proj.addSourceFile('file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addSourceFile('file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -93,17 +93,17 @@ exports.addSourceFile = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addSourceFile('file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addSourceFile('file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const commentKey = newFile.fileRef + '_comment';
 
         test.equal(fileRefSection[commentKey], 'file.m');
         test.done();
     },
     'should add the PBXFileReference object correctly': function (test) {
-        var newFile = proj.addSourceFile('Plugins/file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addSourceFile('Plugins/file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, 4);
@@ -115,32 +115,32 @@ exports.addSourceFile = {
         test.done();
     },
     'should add to the Plugins PBXGroup group': function (test) {
-        var newFile = proj.addSourceFile('Plugins/file.m'),
-            plugins = proj.pbxGroupByName('Plugins');
+        const newFile = proj.addSourceFile('Plugins/file.m');
+        const plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 1);
         test.done();
     },
     'should have the right values for the PBXGroup entry': function (test) {
-        var newFile = proj.addSourceFile('Plugins/file.m'),
-            plugins = proj.pbxGroupByName('Plugins'),
-            pluginObj = plugins.children[0];
+        const newFile = proj.addSourceFile('Plugins/file.m');
+        const plugins = proj.pbxGroupByName('Plugins');
+        const pluginObj = plugins.children[0];
 
         test.equal(pluginObj.comment, 'file.m');
         test.equal(pluginObj.value, newFile.fileRef);
         test.done();
     },
     'should add to the PBXSourcesBuildPhase': function (test) {
-        var newFile = proj.addSourceFile('Plugins/file.m'),
-            sources = proj.pbxSourcesBuildPhaseObj();
+        const newFile = proj.addSourceFile('Plugins/file.m');
+        const sources = proj.pbxSourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 3);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
-        var newFile = proj.addSourceFile('Plugins/file.m'),
-            sources = proj.pbxSourcesBuildPhaseObj(),
-            sourceObj = sources.files[2];
+        const newFile = proj.addSourceFile('Plugins/file.m');
+        const sources = proj.pbxSourcesBuildPhaseObj();
+        const sourceObj = sources.files[2];
 
         test.equal(sourceObj.comment, 'file.m in Sources');
         test.equal(sourceObj.value, newFile.uuid);
@@ -148,19 +148,19 @@ exports.addSourceFile = {
     },
     'duplicate entries': {
         'should return false': function (test) {
-            var newFile = proj.addSourceFile('Plugins/file.m');
+            const newFile = proj.addSourceFile('Plugins/file.m');
 
             test.ok(!proj.addSourceFile('Plugins/file.m'));
             test.done();
         },
         'should not add another entry anywhere': function (test) {
-            var newFile = proj.addSourceFile('Plugins/file.m'),
-                buildFileSection = proj.pbxBuildFileSection(),
-                bfsLength = Object.keys(buildFileSection).length,
-                fileRefSection = proj.pbxFileReferenceSection(),
-                frsLength = Object.keys(fileRefSection).length,
-                plugins = proj.pbxGroupByName('Plugins'),
-                sources = proj.pbxSourcesBuildPhaseObj();
+            const newFile = proj.addSourceFile('Plugins/file.m');
+            const buildFileSection = proj.pbxBuildFileSection();
+            const bfsLength = Object.keys(buildFileSection).length;
+            const fileRefSection = proj.pbxFileReferenceSection();
+            const frsLength = Object.keys(fileRefSection).length;
+            const plugins = proj.pbxGroupByName('Plugins');
+            const sources = proj.pbxSourcesBuildPhaseObj();
 
             // duplicate!
             proj.addSourceFile('Plugins/file.m');

--- a/test/addSourceFile.js
+++ b/test/addSourceFile.js
@@ -21,33 +21,33 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addSourceFile = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addSourceFile('file.m');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         var newFile = proj.addSourceFile('file.m');
 
         test.ok(newFile.uuid);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addSourceFile('file.m');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
         var newFile = proj.addSourceFile('file.m'),
@@ -79,7 +79,9 @@ exports.addSourceFile = {
 
         test.done();
     },
-    'should populate the PBXFileReference section with 2 fields': function (test) {
+    'should populate the PBXFileReference section with 2 fields': function (
+        test
+    ) {
         var newFile = proj.addSourceFile('file.m'),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -163,12 +165,11 @@ exports.addSourceFile = {
             // duplicate!
             proj.addSourceFile('Plugins/file.m');
 
-            test.equal(60, bfsLength);              // BuildFileSection
-            test.equal(68, frsLength);              // FileReferenceSection
+            test.equal(60, bfsLength); // BuildFileSection
+            test.equal(68, frsLength); // FileReferenceSection
             test.equal(plugins.children.length, 1); // Plugins pbxGroup
-            test.equal(sources.files.length, 3);    // SourcesBuildPhhase
+            test.equal(sources.files.length, 3); // SourcesBuildPhhase
             test.done();
         }
     }
-}
-
+};

--- a/test/addStaticLibrary.js
+++ b/test/addStaticLibrary.js
@@ -15,20 +15,20 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 function nonComments (obj) {
-    var keys = Object.keys(obj),
-        newObj = {},
-        i = 0;
+    const keys = Object.keys(obj);
+    const newObj = {};
+    let i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -40,11 +40,11 @@ function nonComments (obj) {
 }
 
 function librarySearchPaths (proj) {
-    var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
-        allPaths = [],
-        ids = Object.keys(configs),
-        i,
-        buildSettings;
+    const configs = nonComments(proj.pbxXCBuildConfigurationSection());
+    const allPaths = [];
+    const ids = Object.keys(configs);
+    let i;
+    let buildSettings;
 
     for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
@@ -64,19 +64,19 @@ exports.setUp = function (callback) {
 
 exports.addStaticLibrary = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
 
         test.ok(newFile.fileRef);
         test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
         (buildFileSection = proj.pbxBuildFileSection()),
         (bfsLength = Object.keys(buildFileSection).length);
 
@@ -89,7 +89,7 @@ exports.addStaticLibrary = {
     'should populate the PBXBuildFile section with 2 fields as plugin': function (
         test
     ) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
             plugin: true
         });
         (buildFileSection = proj.pbxBuildFileSection()),
@@ -102,7 +102,7 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add the PBXBuildFile comment correctly': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
         (commentKey = newFile.uuid + '_comment'),
         (buildFileSection = proj.pbxBuildFileSection());
 
@@ -113,7 +113,7 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
         (buildFileSection = proj.pbxBuildFileSection()),
         (buildFileEntry = buildFileSection[newFile.uuid]);
 
@@ -126,7 +126,7 @@ exports.addStaticLibrary = {
     'should populate the PBXFileReference section with 2 fields': function (
         test
     ) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
         (fileRefSection = proj.pbxFileReferenceSection()),
         (frsLength = Object.keys(fileRefSection).length);
 
@@ -137,7 +137,7 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
         (fileRefSection = proj.pbxFileReferenceSection()),
         (commentKey = newFile.fileRef + '_comment');
 
@@ -145,9 +145,9 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add the PBXFileReference object correctly': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.lastKnownFileType, 'archive.ar');
@@ -158,16 +158,16 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add to the PBXFrameworksBuildPhase': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj(),
-            framework = frameworks.files[15];
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const framework = frameworks.files[15];
 
         test.equal(framework.comment, 'libGoogleAnalytics.a in Frameworks');
         test.equal(framework.value, newFile.uuid);
@@ -176,11 +176,11 @@ exports.addStaticLibrary = {
     'should set LIBRARY_SEARCH_PATHS for appropriate build configurations': function (
         test
     ) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            configs = nonComments(proj.pbxXCBuildConfigurationSection()),
-            ids = Object.keys(configs),
-            i,
-            buildSettings;
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const configs = nonComments(proj.pbxXCBuildConfigurationSection());
+        const ids = Object.keys(configs);
+        let i;
+        let buildSettings;
 
         for (i = 0; i < ids.length; i++) {
             buildSettings = configs[ids[i]].buildSettings;
@@ -195,11 +195,11 @@ exports.addStaticLibrary = {
     'should ensure LIBRARY_SEARCH_PATHS inherits defaults correctly': function (
         test
     ) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            libraryPaths = librarySearchPaths(proj),
-            expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""',
-            i,
-            current;
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const libraryPaths = librarySearchPaths(proj);
+        const expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""';
+        let i;
+        let current;
 
         for (i = 0; i < libraryPaths.length; i++) {
             current = libraryPaths[i];
@@ -211,11 +211,11 @@ exports.addStaticLibrary = {
     'should ensure the new library is in LIBRARY_SEARCH_PATHS': function (
         test
     ) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
-            libraryPaths = librarySearchPaths(proj),
-            expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""',
-            i,
-            current;
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+        const libraryPaths = librarySearchPaths(proj);
+        const expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""';
+        let i;
+        let current;
 
         for (i = 0; i < libraryPaths.length; i++) {
             current = libraryPaths[i];
@@ -225,10 +225,10 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add to the Plugins group, optionally': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
-                plugin: true
-            }),
-            plugins = proj.pbxGroupByName('Plugins');
+        const newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
+            plugin: true
+        });
+        const plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 1);
         test.done();
@@ -238,14 +238,14 @@ exports.addStaticLibrary = {
             plugins = proj.pbxGroupByName('Plugins');
             plugins.path = '"Test200/Plugins"';
 
-            var newFile = proj.addStaticLibrary(
-                    'Plugins/libGoogleAnalytics.a',
-                    { plugin: true }
-                ),
-                libraryPaths = librarySearchPaths(proj),
-                expectedPath = '"\\"$(SRCROOT)/Test200/Plugins\\""',
-                i,
-                current;
+            const newFile = proj.addStaticLibrary(
+                'Plugins/libGoogleAnalytics.a',
+                { plugin: true }
+            );
+            const libraryPaths = librarySearchPaths(proj);
+            const expectedPath = '"\\"$(SRCROOT)/Test200/Plugins\\""';
+            let i;
+            let current;
 
             for (i = 0; i < libraryPaths.length; i++) {
                 current = libraryPaths[i];
@@ -261,14 +261,14 @@ exports.addStaticLibrary = {
             plugins = proj.pbxGroupByName('Plugins');
             delete plugins.path;
 
-            var newFile = proj.addStaticLibrary(
-                    'Plugins/libGoogleAnalytics.a',
-                    { plugin: true }
-                ),
-                libraryPaths = librarySearchPaths(proj),
-                expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet/Plugins\\""',
-                i,
-                current;
+            const newFile = proj.addStaticLibrary(
+                'Plugins/libGoogleAnalytics.a',
+                { plugin: true }
+            );
+            const libraryPaths = librarySearchPaths(proj);
+            const expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet/Plugins\\""';
+            let i;
+            let current;
 
             for (i = 0; i < libraryPaths.length; i++) {
                 current = libraryPaths[i];
@@ -283,13 +283,13 @@ exports.addStaticLibrary = {
     },
     'duplicate entries': {
         'should return false': function (test) {
-            var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
+            const newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
 
             test.ok(!proj.addStaticLibrary('libGoogleAnalytics.a'));
             test.done();
         },
         'should return false (plugin entries)': function (test) {
-            var newFile = proj.addStaticLibrary(
+            const newFile = proj.addStaticLibrary(
                 'Plugins/libGoogleAnalytics.a',
                 { plugin: true }
             );

--- a/test/addStaticLibrary.js
+++ b/test/addStaticLibrary.js
@@ -21,13 +21,14 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
-function nonComments(obj) {
+function nonComments (obj) {
     var keys = Object.keys(obj),
-        newObj = {}, i = 0;
+        newObj = {},
+        i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -38,12 +39,14 @@ function nonComments(obj) {
     return newObj;
 }
 
-function librarySearchPaths(proj) {
+function librarySearchPaths (proj) {
     var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
         allPaths = [],
-        ids = Object.keys(configs), i, buildSettings;
+        ids = Object.keys(configs),
+        i,
+        buildSettings;
 
-    for (i = 0; i< ids.length; i++) {
+    for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
 
         if (buildSettings['LIBRARY_SEARCH_PATHS']) {
@@ -57,25 +60,25 @@ function librarySearchPaths(proj) {
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addStaticLibrary = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        (buildFileSection = proj.pbxBuildFileSection()),
+        (bfsLength = Object.keys(buildFileSection).length);
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -83,11 +86,14 @@ exports.addStaticLibrary = {
 
         test.done();
     },
-    'should populate the PBXBuildFile section with 2 fields as plugin': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a',
-                { plugin: true });
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+    'should populate the PBXBuildFile section with 2 fields as plugin': function (
+        test
+    ) {
+        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
+            plugin: true
+        });
+        (buildFileSection = proj.pbxBuildFileSection()),
+        (bfsLength = Object.keys(buildFileSection).length);
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -97,16 +103,19 @@ exports.addStaticLibrary = {
     },
     'should add the PBXBuildFile comment correctly': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        (commentKey = newFile.uuid + '_comment'),
+        (buildFileSection = proj.pbxBuildFileSection());
 
-        test.equal(buildFileSection[commentKey], 'libGoogleAnalytics.a in Frameworks');
+        test.equal(
+            buildFileSection[commentKey],
+            'libGoogleAnalytics.a in Frameworks'
+        );
         test.done();
     },
     'should add the PBXBuildFile object correctly': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        (buildFileSection = proj.pbxBuildFileSection()),
+        (buildFileEntry = buildFileSection[newFile.uuid]);
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
@@ -114,10 +123,12 @@ exports.addStaticLibrary = {
 
         test.done();
     },
-    'should populate the PBXFileReference section with 2 fields': function (test) {
+    'should populate the PBXFileReference section with 2 fields': function (
+        test
+    ) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        (fileRefSection = proj.pbxFileReferenceSection()),
+        (frsLength = Object.keys(fileRefSection).length);
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -127,8 +138,8 @@ exports.addStaticLibrary = {
     },
     'should populate the PBXFileReference comment correctly': function (test) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a');
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        (fileRefSection = proj.pbxFileReferenceSection()),
+        (commentKey = newFile.fileRef + '_comment');
 
         test.equal(fileRefSection[commentKey], 'libGoogleAnalytics.a');
         test.done();
@@ -162,12 +173,16 @@ exports.addStaticLibrary = {
         test.equal(framework.value, newFile.uuid);
         test.done();
     },
-    'should set LIBRARY_SEARCH_PATHS for appropriate build configurations': function (test) {
+    'should set LIBRARY_SEARCH_PATHS for appropriate build configurations': function (
+        test
+    ) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
             configs = nonComments(proj.pbxXCBuildConfigurationSection()),
-            ids = Object.keys(configs), i, buildSettings;
+            ids = Object.keys(configs),
+            i,
+            buildSettings;
 
-        for (i = 0; i< ids.length; i++) {
+        for (i = 0; i < ids.length; i++) {
             buildSettings = configs[ids[i]].buildSettings;
 
             if (buildSettings['PRODUCT_NAME'] == '"KitchenSinktablet"') {
@@ -177,11 +192,14 @@ exports.addStaticLibrary = {
 
         test.done();
     },
-    'should ensure LIBRARY_SEARCH_PATHS inherits defaults correctly': function (test) {
+    'should ensure LIBRARY_SEARCH_PATHS inherits defaults correctly': function (
+        test
+    ) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
             libraryPaths = librarySearchPaths(proj),
             expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""',
-            i, current;
+            i,
+            current;
 
         for (i = 0; i < libraryPaths.length; i++) {
             current = libraryPaths[i];
@@ -190,11 +208,14 @@ exports.addStaticLibrary = {
 
         test.done();
     },
-    'should ensure the new library is in LIBRARY_SEARCH_PATHS': function (test) {
+    'should ensure the new library is in LIBRARY_SEARCH_PATHS': function (
+        test
+    ) {
         var newFile = proj.addStaticLibrary('libGoogleAnalytics.a'),
             libraryPaths = librarySearchPaths(proj),
             expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet\\""',
-            i, current;
+            i,
+            current;
 
         for (i = 0; i < libraryPaths.length; i++) {
             current = libraryPaths[i];
@@ -204,8 +225,9 @@ exports.addStaticLibrary = {
         test.done();
     },
     'should add to the Plugins group, optionally': function (test) {
-        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a',
-                                        { plugin: true }),
+        var newFile = proj.addStaticLibrary('libGoogleAnalytics.a', {
+                plugin: true
+            }),
             plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 1);
@@ -216,16 +238,21 @@ exports.addStaticLibrary = {
             plugins = proj.pbxGroupByName('Plugins');
             plugins.path = '"Test200/Plugins"';
 
-            var newFile = proj.addStaticLibrary('Plugins/libGoogleAnalytics.a',
-                                            { plugin: true }),
+            var newFile = proj.addStaticLibrary(
+                    'Plugins/libGoogleAnalytics.a',
+                    { plugin: true }
+                ),
                 libraryPaths = librarySearchPaths(proj),
                 expectedPath = '"\\"$(SRCROOT)/Test200/Plugins\\""',
-                i, current;
+                i,
+                current;
 
             for (i = 0; i < libraryPaths.length; i++) {
                 current = libraryPaths[i];
-                test.ok(current.indexOf(expectedPath) >= 0,
-                       expectedPath + ' not found in ' + current);
+                test.ok(
+                    current.indexOf(expectedPath) >= 0,
+                    expectedPath + ' not found in ' + current
+                );
             }
 
             test.done();
@@ -234,16 +261,21 @@ exports.addStaticLibrary = {
             plugins = proj.pbxGroupByName('Plugins');
             delete plugins.path;
 
-            var newFile = proj.addStaticLibrary('Plugins/libGoogleAnalytics.a',
-                                            { plugin: true }),
+            var newFile = proj.addStaticLibrary(
+                    'Plugins/libGoogleAnalytics.a',
+                    { plugin: true }
+                ),
                 libraryPaths = librarySearchPaths(proj),
                 expectedPath = '"\\"$(SRCROOT)/KitchenSinktablet/Plugins\\""',
-                i, current;
+                i,
+                current;
 
             for (i = 0; i < libraryPaths.length; i++) {
                 current = libraryPaths[i];
-                test.ok(current.indexOf(expectedPath) >= 0,
-                       expectedPath + ' not found in ' + current);
+                test.ok(
+                    current.indexOf(expectedPath) >= 0,
+                    expectedPath + ' not found in ' + current
+                );
             }
 
             test.done();
@@ -257,12 +289,17 @@ exports.addStaticLibrary = {
             test.done();
         },
         'should return false (plugin entries)': function (test) {
-            var newFile = proj.addStaticLibrary('Plugins/libGoogleAnalytics.a',
-                                                { plugin: true });
+            var newFile = proj.addStaticLibrary(
+                'Plugins/libGoogleAnalytics.a',
+                { plugin: true }
+            );
 
-            test.ok(!proj.addStaticLibrary('Plugins/libGoogleAnalytics.a',
-                                                { plugin: true }));
+            test.ok(
+                !proj.addStaticLibrary('Plugins/libGoogleAnalytics.a', {
+                    plugin: true
+                })
+            );
             test.done();
-        },
+        }
     }
-}
+};

--- a/test/addStaticLibrary.js
+++ b/test/addStaticLibrary.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -18,6 +18,7 @@
 var fullProject = require('./fixtures/full-project')
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
 function cleanHash() {

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -15,19 +15,19 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
-var TARGET_NAME = 'TestExtension',
-    TARGET_TYPE = 'app_extension',
-    TARGET_SUBFOLDER_NAME = 'TestExtensionFiles';
+const TARGET_NAME = 'TestExtension';
+const TARGET_TYPE = 'app_extension';
+const TARGET_SUBFOLDER_NAME = 'TestExtensionFiles';
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
@@ -50,7 +50,7 @@ exports.addTarget = {
         test.done();
     },
     'should create a new target': function (test) {
-        var target = proj.addTarget(
+        const target = proj.addTarget(
             TARGET_NAME,
             TARGET_TYPE,
             TARGET_SUBFOLDER_NAME
@@ -74,28 +74,28 @@ exports.addTarget = {
     'should create a new target and add source, framework, resource and header files and the corresponding build phases': function (
         test
     ) {
-        var target = proj.addTarget(
-                TARGET_NAME,
-                TARGET_TYPE,
-                TARGET_SUBFOLDER_NAME
-            ),
-            options = { target: target.uuid };
+        const target = proj.addTarget(
+            TARGET_NAME,
+            TARGET_TYPE,
+            TARGET_SUBFOLDER_NAME
+        );
+        const options = { target: target.uuid };
 
-        var sourceFile = proj.addSourceFile('Plugins/file.m', options),
-            sourcePhase = proj.addBuildPhase(
-                [],
-                'PBXSourcesBuildPhase',
-                'Sources',
-                target.uuid
-            ),
-            resourceFile = proj.addResourceFile('assets.bundle', options),
-            resourcePhase = proj.addBuildPhase(
-                [],
-                'PBXResourcesBuildPhase',
-                'Resources',
-                target.uuid
-            ),
-            frameworkFile = proj.addFramework('libsqlite3.dylib', options);
+        const sourceFile = proj.addSourceFile('Plugins/file.m', options);
+        const sourcePhase = proj.addBuildPhase(
+            [],
+            'PBXSourcesBuildPhase',
+            'Sources',
+            target.uuid
+        );
+        const resourceFile = proj.addResourceFile('assets.bundle', options);
+        const resourcePhase = proj.addBuildPhase(
+            [],
+            'PBXResourcesBuildPhase',
+            'Resources',
+            target.uuid
+        );
+        const frameworkFile = proj.addFramework('libsqlite3.dylib', options);
         (frameworkPhase = proj.addBuildPhase(
             [],
             'PBXFrameworkBuildPhase',

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -21,7 +21,7 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
@@ -32,25 +32,29 @@ var TARGET_NAME = 'TestExtension',
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addTarget = {
     'should throw when target name is missing': function (test) {
-        test.throws(function() {
+        test.throws(function () {
             proj.addTarget(null, TARGET_TYPE);
         });
 
         test.done();
     },
     'should throw when target type missing': function (test) {
-        test.throws(function() {
+        test.throws(function () {
             proj.addTarget(TARGET_NAME, null);
         });
 
         test.done();
     },
     'should create a new target': function (test) {
-        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
+        var target = proj.addTarget(
+            TARGET_NAME,
+            TARGET_TYPE,
+            TARGET_SUBFOLDER_NAME
+        );
 
         test.ok(typeof target == 'object');
         test.ok(target.uuid);
@@ -67,17 +71,38 @@ exports.addTarget = {
 
         test.done();
     },
-    'should create a new target and add source, framework, resource and header files and the corresponding build phases': function (test) {
-        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME),
-            options = { 'target' : target.uuid };
+    'should create a new target and add source, framework, resource and header files and the corresponding build phases': function (
+        test
+    ) {
+        var target = proj.addTarget(
+                TARGET_NAME,
+                TARGET_TYPE,
+                TARGET_SUBFOLDER_NAME
+            ),
+            options = { target: target.uuid };
 
         var sourceFile = proj.addSourceFile('Plugins/file.m', options),
-            sourcePhase = proj.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid),
+            sourcePhase = proj.addBuildPhase(
+                [],
+                'PBXSourcesBuildPhase',
+                'Sources',
+                target.uuid
+            ),
             resourceFile = proj.addResourceFile('assets.bundle', options),
-            resourcePhase = proj.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', target.uuid),
+            resourcePhase = proj.addBuildPhase(
+                [],
+                'PBXResourcesBuildPhase',
+                'Resources',
+                target.uuid
+            ),
             frameworkFile = proj.addFramework('libsqlite3.dylib', options);
-            frameworkPhase = proj.addBuildPhase([], 'PBXFrameworkBuildPhase', 'Frameworks', target.uuid),
-            headerFile = proj.addHeaderFile('file.h', options);
+        (frameworkPhase = proj.addBuildPhase(
+            [],
+            'PBXFrameworkBuildPhase',
+            'Frameworks',
+            target.uuid
+        )),
+        (headerFile = proj.addHeaderFile('file.h', options));
 
         test.ok(sourcePhase);
         test.ok(resourcePhase);
@@ -103,4 +128,4 @@ exports.addTarget = {
 
         test.done();
     }
-}
+};

--- a/test/addTargetDependency.js
+++ b/test/addTargetDependency.js
@@ -20,36 +20,44 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addTargetDependency = {
     'should return undefined when no target specified': function (test) {
         var buildPhase = proj.addTargetDependency();
 
         test.ok(typeof buildPhase === 'undefined');
-        test.done()
+        test.done();
     },
-    'should throw when target not found in nativeTargetsSection': function (test) {
-        test.throws(function() {
+    'should throw when target not found in nativeTargetsSection': function (
+        test
+    ) {
+        test.throws(function () {
             proj.addTargetDependency('invalidTarget');
         });
-        test.done()
+        test.done();
     },
-    'should throw when any dependency target not found in nativeTargetsSection': function (test) {
-        test.throws(function() {
-            proj.addTargetDependency('1D6058900D05DD3D006BFB54', ['invalidTarget']);
+    'should throw when any dependency target not found in nativeTargetsSection': function (
+        test
+    ) {
+        test.throws(function () {
+            proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+                'invalidTarget'
+            ]);
         });
-        test.done()
+        test.done();
     },
     'should return the pbxTarget': function (test) {
-        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', ['1D6058900D05DD3D006BFB54']);
+        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+            '1D6058900D05DD3D006BFB54'
+        ]);
 
         test.ok(typeof target == 'object');
         test.ok(target.uuid);
@@ -57,107 +65,181 @@ exports.addTargetDependency = {
         test.done();
     },
     'should add targetDependencies to target': function (test) {
-        var targetInPbxProj = proj.pbxNativeTargetSection()['1D6058900D05DD3D006BFB55'];
+        var targetInPbxProj = proj.pbxNativeTargetSection()[
+            '1D6058900D05DD3D006BFB55'
+        ];
         test.deepEqual(targetInPbxProj.dependencies, []);
 
-        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
-        test.deepEqual(targetInPbxProj.dependencies, target.dependencies)
-        test.done()
+        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
+        test.deepEqual(targetInPbxProj.dependencies, target.dependencies);
+        test.done();
     },
-    'should create a PBXTargetDependency for each dependency target': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
+    'should create a PBXTargetDependency for each dependency target': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target;
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value;
             test.ok(pbxTargetDependencySection[dependency]);
         }
 
-        test.done()
+        test.done();
     },
     'should set right comment for each dependency target': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target;
 
         for (var index = 0; index < target.dependencies.length; index++) {
-            var dependencyCommentKey = target.dependencies[index].value + '_comment';
-            test.equal(pbxTargetDependencySection[dependencyCommentKey], 'PBXTargetDependency');
+            var dependencyCommentKey =
+                target.dependencies[index].value + '_comment';
+            test.equal(
+                pbxTargetDependencySection[dependencyCommentKey],
+                'PBXTargetDependency'
+            );
         }
 
-        test.done()
+        test.done();
     },
-    'should create a PBXContainerItemProxy for each PBXTargetDependency': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection = proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
+    'should create a PBXContainerItemProxy for each PBXTargetDependency': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target;
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value,
-                targetProxy = pbxTargetDependencySection[dependency]['targetProxy'];
+                targetProxy =
+                    pbxTargetDependencySection[dependency]['targetProxy'];
 
             test.ok(pbxContainerItemProxySection[targetProxy]);
         }
 
-        test.done()
+        test.done();
     },
-    'should set each PBXContainerItemProxy`s remoteGlobalIDString correctly': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection = proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target,
+    'should set each PBXContainerItemProxy`s remoteGlobalIDString correctly': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target,
             remoteGlobalIDStrings = [];
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value,
-                targetProxy = pbxTargetDependencySection[dependency]['targetProxy'];
+                targetProxy =
+                    pbxTargetDependencySection[dependency]['targetProxy'];
 
-            remoteGlobalIDStrings.push(pbxContainerItemProxySection[targetProxy]['remoteGlobalIDString']);
+            remoteGlobalIDStrings.push(
+                pbxContainerItemProxySection[targetProxy][
+                    'remoteGlobalIDString'
+                ]
+            );
         }
 
-        test.deepEqual(remoteGlobalIDStrings, ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']);
-        test.done()
+        test.deepEqual(remoteGlobalIDStrings, [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]);
+        test.done();
     },
-    'should set each PBXContainerItemProxy`s remoteInfo correctly': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection = proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target,
+    'should set each PBXContainerItemProxy`s remoteInfo correctly': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target,
             remoteInfoArray = [];
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value,
-                targetProxy = pbxTargetDependencySection[dependency]['targetProxy'];
+                targetProxy =
+                    pbxTargetDependencySection[dependency]['targetProxy'];
 
-            remoteInfoArray.push(pbxContainerItemProxySection[targetProxy]['remoteInfo']);
+            remoteInfoArray.push(
+                pbxContainerItemProxySection[targetProxy]['remoteInfo']
+            );
         }
 
         test.deepEqual(remoteInfoArray, ['"KitchenSinktablet"', '"TestApp"']);
-        test.done()
+        test.done();
     },
-    'should set each PBXContainerItemProxy`s containerPortal correctly': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection = proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
+    'should set each PBXContainerItemProxy`s containerPortal correctly': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target;
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value,
-                targetProxy = pbxTargetDependencySection[dependency]['targetProxy'];
+                targetProxy =
+                    pbxTargetDependencySection[dependency]['targetProxy'];
 
-            test.equal(pbxContainerItemProxySection[targetProxy]['containerPortal'], proj.hash.project['rootObject']);
+            test.equal(
+                pbxContainerItemProxySection[targetProxy]['containerPortal'],
+                proj.hash.project['rootObject']
+            );
         }
 
-        test.done()
+        test.done();
     },
-    'should set each PBXContainerItemProxy`s proxyType correctly': function (test) {
-        var pbxTargetDependencySection = proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection = proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;
+    'should set each PBXContainerItemProxy`s proxyType correctly': function (
+        test
+    ) {
+        var pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'],
+            pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'],
+            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+                '1D6058900D05DD3D006BFB54',
+                '1D6058900D05DD3D006BFB55'
+            ]).target;
 
         for (var index = 0; index < target.dependencies.length; index++) {
             var dependency = target.dependencies[index].value,
-                targetProxy = pbxTargetDependencySection[dependency]['targetProxy'];
+                targetProxy =
+                    pbxTargetDependencySection[dependency]['targetProxy'];
 
-            test.equal(pbxContainerItemProxySection[targetProxy]['proxyType'], 1);
+            test.equal(
+                pbxContainerItemProxySection[targetProxy]['proxyType'],
+                1
+            );
         }
 
-        test.done()
+        test.done();
     }
-}
+};

--- a/test/addTargetDependency.js
+++ b/test/addTargetDependency.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,7 +31,7 @@ exports.setUp = function (callback) {
 
 exports.addTargetDependency = {
     'should return undefined when no target specified': function (test) {
-        var buildPhase = proj.addTargetDependency();
+        const buildPhase = proj.addTargetDependency();
 
         test.ok(typeof buildPhase === 'undefined');
         test.done();
@@ -55,7 +55,7 @@ exports.addTargetDependency = {
         test.done();
     },
     'should return the pbxTarget': function (test) {
-        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
             '1D6058900D05DD3D006BFB54'
         ]);
 
@@ -65,12 +65,12 @@ exports.addTargetDependency = {
         test.done();
     },
     'should add targetDependencies to target': function (test) {
-        var targetInPbxProj = proj.pbxNativeTargetSection()[
+        const targetInPbxProj = proj.pbxNativeTargetSection()[
             '1D6058900D05DD3D006BFB55'
         ];
         test.deepEqual(targetInPbxProj.dependencies, []);
 
-        var target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
             '1D6058900D05DD3D006BFB54',
             '1D6058900D05DD3D006BFB55'
         ]).target;
@@ -80,30 +80,30 @@ exports.addTargetDependency = {
     'should create a PBXTargetDependency for each dependency target': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target;
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value;
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
             test.ok(pbxTargetDependencySection[dependency]);
         }
 
         test.done();
     },
     'should set right comment for each dependency target': function (test) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target;
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependencyCommentKey =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependencyCommentKey =
                 target.dependencies[index].value + '_comment';
             test.equal(
                 pbxTargetDependencySection[dependencyCommentKey],
@@ -116,18 +116,18 @@ exports.addTargetDependency = {
     'should create a PBXContainerItemProxy for each PBXTargetDependency': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection =
-                proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target;
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB54', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value,
-                targetProxy =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
+            const targetProxy =
                     pbxTargetDependencySection[dependency]['targetProxy'];
 
             test.ok(pbxContainerItemProxySection[targetProxy]);
@@ -138,19 +138,19 @@ exports.addTargetDependency = {
     'should set each PBXContainerItemProxy`s remoteGlobalIDString correctly': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection =
-                proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target,
-            remoteGlobalIDStrings = [];
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
+        const remoteGlobalIDStrings = [];
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value,
-                targetProxy =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
+            const targetProxy =
                     pbxTargetDependencySection[dependency]['targetProxy'];
 
             remoteGlobalIDStrings.push(
@@ -169,19 +169,19 @@ exports.addTargetDependency = {
     'should set each PBXContainerItemProxy`s remoteInfo correctly': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection =
-                proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target,
-            remoteInfoArray = [];
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
+        const remoteInfoArray = [];
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value,
-                targetProxy =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
+            const targetProxy =
                     pbxTargetDependencySection[dependency]['targetProxy'];
 
             remoteInfoArray.push(
@@ -195,18 +195,18 @@ exports.addTargetDependency = {
     'should set each PBXContainerItemProxy`s containerPortal correctly': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection =
-                proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target;
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value,
-                targetProxy =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
+            const targetProxy =
                     pbxTargetDependencySection[dependency]['targetProxy'];
 
             test.equal(
@@ -220,18 +220,18 @@ exports.addTargetDependency = {
     'should set each PBXContainerItemProxy`s proxyType correctly': function (
         test
     ) {
-        var pbxTargetDependencySection =
-                proj.hash.project.objects['PBXTargetDependency'],
-            pbxContainerItemProxySection =
-                proj.hash.project.objects['PBXContainerItemProxy'],
-            target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
-                '1D6058900D05DD3D006BFB54',
-                '1D6058900D05DD3D006BFB55'
-            ]).target;
+        const pbxTargetDependencySection =
+                proj.hash.project.objects['PBXTargetDependency'];
+        const pbxContainerItemProxySection =
+                proj.hash.project.objects['PBXContainerItemProxy'];
+        const target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', [
+            '1D6058900D05DD3D006BFB54',
+            '1D6058900D05DD3D006BFB55'
+        ]).target;
 
-        for (var index = 0; index < target.dependencies.length; index++) {
-            var dependency = target.dependencies[index].value,
-                targetProxy =
+        for (let index = 0; index < target.dependencies.length; index++) {
+            const dependency = target.dependencies[index].value;
+            const targetProxy =
                     pbxTargetDependencySection[dependency]['targetProxy'];
 
             test.equal(

--- a/test/addTargetDependency.js
+++ b/test/addTargetDependency.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');

--- a/test/addToPbxFileReferenceSection.js
+++ b/test/addToPbxFileReferenceSection.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var jsonProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(jsonProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    myProj = new pbx('.');
+const jsonProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(jsonProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const myProj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,7 +32,7 @@ exports.setUp = function (callback) {
 
 exports['addToPbxFileReferenceSection function'] = {
     'should add file and comment to fileReferenceSection': function (test) {
-        var file = new pbxFile('file.m');
+        const file = new pbxFile('file.m');
         file.fileRef = myProj.generateUuid();
 
         myProj.addToPbxFileReferenceSection(file);
@@ -70,7 +70,7 @@ exports['addToPbxFileReferenceSection function'] = {
     'should add file with preset explicitFileType to fileReferenceSection correctly': function (
         test
     ) {
-        var appexFile = {
+        const appexFile = {
             fileRef: myProj.generateUuid(),
             isa: 'PBXFileReference',
             explicitFileType: '"wrapper.app-extension"',
@@ -97,7 +97,7 @@ exports['addToPbxFileReferenceSection function'] = {
     'should add file with preset includeInIndex to fileReferenceSection correctly': function (
         test
     ) {
-        var appexFile = {
+        const appexFile = {
             fileRef: myProj.generateUuid(),
             isa: 'PBXFileReference',
             includeInIndex: 0,
@@ -124,7 +124,7 @@ exports['addToPbxFileReferenceSection function'] = {
     'should add file with preset sourceTree to fileReferenceSection correctly': function (
         test
     ) {
-        var appexFile = {
+        const appexFile = {
             fileRef: myProj.generateUuid(),
             isa: 'PBXFileReference',
             sourceTree: 'BUILT_PRODUCTS_DIR',

--- a/test/addToPbxFileReferenceSection.js
+++ b/test/addToPbxFileReferenceSection.js
@@ -21,59 +21,130 @@ var jsonProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     myProj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     myProj.hash = cleanHash();
     callback();
-}
+};
 
 exports['addToPbxFileReferenceSection function'] = {
     'should add file and comment to fileReferenceSection': function (test) {
         var file = new pbxFile('file.m');
         file.fileRef = myProj.generateUuid();
 
-        myProj.addToPbxFileReferenceSection(file)
+        myProj.addToPbxFileReferenceSection(file);
 
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].isa, 'PBXFileReference');
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].lastKnownFileType, 'sourcecode.c.objc');
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].name, '"file.m"');
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].path, '"file.m"');
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].sourceTree, '"<group>"');
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef].fileEncoding, 4);
-        test.equal(myProj.pbxFileReferenceSection()[file.fileRef + "_comment"], 'file.m');
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].isa,
+            'PBXFileReference'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].lastKnownFileType,
+            'sourcecode.c.objc'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].name,
+            '"file.m"'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].path,
+            '"file.m"'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].sourceTree,
+            '"<group>"'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef].fileEncoding,
+            4
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[file.fileRef + '_comment'],
+            'file.m'
+        );
         test.done();
     },
-    'should add file with preset explicitFileType to fileReferenceSection correctly': function (test) {
-        var appexFile = { fileRef: myProj.generateUuid(), isa: 'PBXFileReference', explicitFileType: '"wrapper.app-extension"', path: "WatchKit Extension.appex"};
+    'should add file with preset explicitFileType to fileReferenceSection correctly': function (
+        test
+    ) {
+        var appexFile = {
+            fileRef: myProj.generateUuid(),
+            isa: 'PBXFileReference',
+            explicitFileType: '"wrapper.app-extension"',
+            path: 'WatchKit Extension.appex'
+        };
 
-        myProj.addToPbxFileReferenceSection(appexFile)
+        myProj.addToPbxFileReferenceSection(appexFile);
 
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].isa, 'PBXFileReference');
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].explicitFileType, '"wrapper.app-extension"');
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].path, '"WatchKit Extension.appex"');
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].isa,
+            'PBXFileReference'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef]
+                .explicitFileType,
+            '"wrapper.app-extension"'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].path,
+            '"WatchKit Extension.appex"'
+        );
         test.done();
     },
-    'should add file with preset includeInIndex to fileReferenceSection correctly': function (test) {
-        var appexFile = { fileRef: myProj.generateUuid(), isa: 'PBXFileReference', includeInIndex: 0, path: "WatchKit Extension.appex"};
+    'should add file with preset includeInIndex to fileReferenceSection correctly': function (
+        test
+    ) {
+        var appexFile = {
+            fileRef: myProj.generateUuid(),
+            isa: 'PBXFileReference',
+            includeInIndex: 0,
+            path: 'WatchKit Extension.appex'
+        };
 
-        myProj.addToPbxFileReferenceSection(appexFile)
+        myProj.addToPbxFileReferenceSection(appexFile);
 
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].isa, 'PBXFileReference');
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].includeInIndex, 0);
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].path, '"WatchKit Extension.appex"');
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].isa,
+            'PBXFileReference'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef]
+                .includeInIndex,
+            0
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].path,
+            '"WatchKit Extension.appex"'
+        );
         test.done();
     },
-    'should add file with preset sourceTree to fileReferenceSection correctly': function (test) {
-        var appexFile = { fileRef: myProj.generateUuid(), isa: 'PBXFileReference', sourceTree: 'BUILT_PRODUCTS_DIR', path: "WatchKit Extension.appex"};
+    'should add file with preset sourceTree to fileReferenceSection correctly': function (
+        test
+    ) {
+        var appexFile = {
+            fileRef: myProj.generateUuid(),
+            isa: 'PBXFileReference',
+            sourceTree: 'BUILT_PRODUCTS_DIR',
+            path: 'WatchKit Extension.appex'
+        };
 
-        myProj.addToPbxFileReferenceSection(appexFile)
+        myProj.addToPbxFileReferenceSection(appexFile);
 
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].isa, 'PBXFileReference');
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].sourceTree, 'BUILT_PRODUCTS_DIR');
-        test.equal(myProj.pbxFileReferenceSection()[appexFile.fileRef].path, '"WatchKit Extension.appex"');
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].isa,
+            'PBXFileReference'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].sourceTree,
+            'BUILT_PRODUCTS_DIR'
+        );
+        test.equal(
+            myProj.pbxFileReferenceSection()[appexFile.fileRef].path,
+            '"WatchKit Extension.appex"'
+        );
         test.done();
     }
-}
+};

--- a/test/addToPbxFileReferenceSection.js
+++ b/test/addToPbxFileReferenceSection.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var jsonProject = require('./fixtures/full-project')
+var jsonProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(jsonProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/addXCConfigurationList.js
+++ b/test/addXCConfigurationList.js
@@ -15,33 +15,33 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.'),
-    debugConfiguration = {
-        isa: 'XCBuildConfiguration',
-        buildSettings: {
-            GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-            INFOPLIST_FILE: 'Info.Plist',
-            LD_RUNPATH_SEARCH_PATHS:
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
+const debugConfiguration = {
+    isa: 'XCBuildConfiguration',
+    buildSettings: {
+        GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
+        INFOPLIST_FILE: 'Info.Plist',
+        LD_RUNPATH_SEARCH_PATHS:
                 '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-            PRODUCT_NAME: '"${TARGET_NAME}"',
-            SKIP_INSTALL: 'YES'
-        },
-        name: 'Debug'
+        PRODUCT_NAME: '"${TARGET_NAME}"',
+        SKIP_INSTALL: 'YES'
     },
-    releaseConfiguration = {
-        isa: 'XCBuildConfiguration',
-        buildSettings: {
-            INFOPLIST_FILE: 'Info.Plist',
-            LD_RUNPATH_SEARCH_PATHS:
+    name: 'Debug'
+};
+const releaseConfiguration = {
+    isa: 'XCBuildConfiguration',
+    buildSettings: {
+        INFOPLIST_FILE: 'Info.Plist',
+        LD_RUNPATH_SEARCH_PATHS:
                 '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-            PRODUCT_NAME: '"${TARGET_NAME}"',
-            SKIP_INSTALL: 'YES'
-        },
-        name: 'Release'
-    };
+        PRODUCT_NAME: '"${TARGET_NAME}"',
+        SKIP_INSTALL: 'YES'
+    },
+    name: 'Release'
+};
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -54,23 +54,23 @@ exports.setUp = function (callback) {
 
 exports.addXCConfigurationList = {
     'should return an XCConfigurationList': function (test) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            xcConfigurationList = myProj.addXCConfigurationList(
-                [debugConfiguration, releaseConfiguration],
-                'Release',
-                'XCConfigurationList Comment'
-            );
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        );
 
         test.ok(typeof xcConfigurationList === 'object');
         test.done();
     },
     'should set a uuid on the XCConfigurationList': function (test) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            xcConfigurationList = myProj.addXCConfigurationList(
-                [debugConfiguration, releaseConfiguration],
-                'Release',
-                'XCConfigurationList Comment'
-            );
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        );
 
         test.ok(xcConfigurationList.uuid);
         test.done();
@@ -78,22 +78,22 @@ exports.addXCConfigurationList = {
     'should add configurations to pbxBuildConfigurationSection': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection(),
-            xcConfigurationList = myProj.addXCConfigurationList(
-                [debugConfiguration, releaseConfiguration],
-                'Release',
-                'XCConfigurationList Comment'
-            ),
-            xcConfigurationListConfigurations =
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection();
+        const xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        );
+        const xcConfigurationListConfigurations =
                 xcConfigurationList.xcConfigurationList.buildConfigurations;
 
         for (
-            var index = 0;
+            let index = 0;
             index < xcConfigurationListConfigurations.length;
             index++
         ) {
-            var configuration = xcConfigurationListConfigurations[index];
+            const configuration = xcConfigurationListConfigurations[index];
             test.ok(pbxBuildConfigurationSection[configuration.value]);
         }
 
@@ -102,8 +102,8 @@ exports.addXCConfigurationList = {
     'should add XCConfigurationList to pbxXCConfigurationListSection': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
         xcConfigurationList = myProj.addXCConfigurationList(
             [debugConfiguration, releaseConfiguration],
             'Release',
@@ -114,8 +114,8 @@ exports.addXCConfigurationList = {
         test.done();
     },
     'should add XCConfigurationList object correctly': function (test) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
         (xcConfigurationList = myProj.addXCConfigurationList(
             [debugConfiguration, releaseConfiguration],
             'Release',
@@ -133,8 +133,8 @@ exports.addXCConfigurationList = {
     'should add correct configurations to XCConfigurationList and to pbxBuildConfigurationSection': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
         (pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection()),
         (xcConfigurationList = myProj.addXCConfigurationList(
             [debugConfiguration, releaseConfiguration],
@@ -148,11 +148,11 @@ exports.addXCConfigurationList = {
                 pbxXCConfigurationListSection[xcConfigurationList.uuid]);
 
         for (
-            var index = 0;
+            let index = 0;
             index < xcConfigurationListConfigurations.length;
             index++
         ) {
-            var configuration = xcConfigurationListConfigurations[index];
+            const configuration = xcConfigurationListConfigurations[index];
             expectedConfigurations.push(
                 pbxBuildConfigurationSection[configuration.value]
             );
@@ -169,22 +169,22 @@ exports.addXCConfigurationList = {
         test.done();
     },
     'should set comments for pbxBuildConfigurations': function (test) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection(),
-            xcConfigurationList = myProj.addXCConfigurationList(
-                [debugConfiguration, releaseConfiguration],
-                'Release',
-                'XCConfigurationList Comment'
-            ),
-            xcConfigurationListConfigurations =
+        const myProj = new pbx('test/parser/projects/full.pbxproj').parseSync();
+        const pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection();
+        const xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        );
+        const xcConfigurationListConfigurations =
                 xcConfigurationList.xcConfigurationList.buildConfigurations;
 
         for (
-            var index = 0;
+            let index = 0;
             index < xcConfigurationListConfigurations.length;
             index++
         ) {
-            var configuration = xcConfigurationListConfigurations[index];
+            const configuration = xcConfigurationListConfigurations[index];
             test.ok(
                 pbxBuildConfigurationSection[configuration.value + '_comment']
             );

--- a/test/addXCConfigurationList.js
+++ b/test/addXCConfigurationList.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.'),

--- a/test/addXCConfigurationList.js
+++ b/test/addXCConfigurationList.js
@@ -20,71 +20,95 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.'),
     debugConfiguration = {
-		isa: 'XCBuildConfiguration',
-		buildSettings: {
-			GCC_PREPROCESSOR_DEFINITIONS: [
-				'"DEBUG=1"',
-				'"$(inherited)"',
-            ],
-			INFOPLIST_FILE: "Info.Plist",
-			LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-			PRODUCT_NAME: '"${TARGET_NAME}"',
-			SKIP_INSTALL: 'YES'
-		},
-		name: 'Debug'
+        isa: 'XCBuildConfiguration',
+        buildSettings: {
+            GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
+            INFOPLIST_FILE: 'Info.Plist',
+            LD_RUNPATH_SEARCH_PATHS:
+                '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+            PRODUCT_NAME: '"${TARGET_NAME}"',
+            SKIP_INSTALL: 'YES'
+        },
+        name: 'Debug'
     },
     releaseConfiguration = {
-		isa: 'XCBuildConfiguration',
-		buildSettings: {
-			INFOPLIST_FILE: "Info.Plist",
-			LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-			PRODUCT_NAME: '"${TARGET_NAME}"',
-			SKIP_INSTALL: 'YES'
-		},
-		name: 'Release'
-	};
+        isa: 'XCBuildConfiguration',
+        buildSettings: {
+            INFOPLIST_FILE: 'Info.Plist',
+            LD_RUNPATH_SEARCH_PATHS:
+                '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+            PRODUCT_NAME: '"${TARGET_NAME}"',
+            SKIP_INSTALL: 'YES'
+        },
+        name: 'Release'
+    };
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addXCConfigurationList = {
     'should return an XCConfigurationList': function (test) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment');
+            xcConfigurationList = myProj.addXCConfigurationList(
+                [debugConfiguration, releaseConfiguration],
+                'Release',
+                'XCConfigurationList Comment'
+            );
 
         test.ok(typeof xcConfigurationList === 'object');
         test.done();
     },
     'should set a uuid on the XCConfigurationList': function (test) {
-         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment');
+        var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
+            xcConfigurationList = myProj.addXCConfigurationList(
+                [debugConfiguration, releaseConfiguration],
+                'Release',
+                'XCConfigurationList Comment'
+            );
 
         test.ok(xcConfigurationList.uuid);
         test.done();
     },
-    'should add configurations to pbxBuildConfigurationSection': function (test) {
+    'should add configurations to pbxBuildConfigurationSection': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
             pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection(),
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment'),
-            xcConfigurationListConfigurations = xcConfigurationList.xcConfigurationList.buildConfigurations;
+            xcConfigurationList = myProj.addXCConfigurationList(
+                [debugConfiguration, releaseConfiguration],
+                'Release',
+                'XCConfigurationList Comment'
+            ),
+            xcConfigurationListConfigurations =
+                xcConfigurationList.xcConfigurationList.buildConfigurations;
 
-        for (var index = 0; index < xcConfigurationListConfigurations.length; index++) {
+        for (
+            var index = 0;
+            index < xcConfigurationListConfigurations.length;
+            index++
+        ) {
             var configuration = xcConfigurationListConfigurations[index];
             test.ok(pbxBuildConfigurationSection[configuration.value]);
         }
 
         test.done();
     },
-    'should add XCConfigurationList to pbxXCConfigurationListSection': function (test) {
+    'should add XCConfigurationList to pbxXCConfigurationListSection': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
             pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment');
+        xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        );
 
         test.ok(pbxXCConfigurationListSection[xcConfigurationList.uuid]);
         test.done();
@@ -92,41 +116,80 @@ exports.addXCConfigurationList = {
     'should add XCConfigurationList object correctly': function (test) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
             pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment'),
-            xcConfigurationListInPbx = pbxXCConfigurationListSection[xcConfigurationList.uuid];
+        (xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        )),
+        (xcConfigurationListInPbx =
+                pbxXCConfigurationListSection[xcConfigurationList.uuid]);
 
-        test.deepEqual(xcConfigurationListInPbx, xcConfigurationList.xcConfigurationList);
+        test.deepEqual(
+            xcConfigurationListInPbx,
+            xcConfigurationList.xcConfigurationList
+        );
         test.done();
     },
-    'should add correct configurations to XCConfigurationList and to pbxBuildConfigurationSection': function (test) {
+    'should add correct configurations to XCConfigurationList and to pbxBuildConfigurationSection': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
             pbxXCConfigurationListSection = myProj.pbxXCConfigurationList();
-            pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection(),
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment'),
-            xcConfigurationListConfigurations = xcConfigurationList.xcConfigurationList.buildConfigurations,
-            expectedConfigurations = [],
-            xcConfigurationListInPbx = pbxXCConfigurationListSection[xcConfigurationList.uuid];
+        (pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection()),
+        (xcConfigurationList = myProj.addXCConfigurationList(
+            [debugConfiguration, releaseConfiguration],
+            'Release',
+            'XCConfigurationList Comment'
+        )),
+        (xcConfigurationListConfigurations =
+                xcConfigurationList.xcConfigurationList.buildConfigurations),
+        (expectedConfigurations = []),
+        (xcConfigurationListInPbx =
+                pbxXCConfigurationListSection[xcConfigurationList.uuid]);
 
-        for (var index = 0; index < xcConfigurationListConfigurations.length; index++) {
+        for (
+            var index = 0;
+            index < xcConfigurationListConfigurations.length;
+            index++
+        ) {
             var configuration = xcConfigurationListConfigurations[index];
-            expectedConfigurations.push(pbxBuildConfigurationSection[configuration.value]);
+            expectedConfigurations.push(
+                pbxBuildConfigurationSection[configuration.value]
+            );
         }
 
-        test.deepEqual(expectedConfigurations, [debugConfiguration, releaseConfiguration]);
-        test.deepEqual(xcConfigurationListInPbx.buildConfigurations, xcConfigurationListConfigurations);
+        test.deepEqual(expectedConfigurations, [
+            debugConfiguration,
+            releaseConfiguration
+        ]);
+        test.deepEqual(
+            xcConfigurationListInPbx.buildConfigurations,
+            xcConfigurationListConfigurations
+        );
         test.done();
     },
     'should set comments for pbxBuildConfigurations': function (test) {
         var myProj = new pbx('test/parser/projects/full.pbxproj').parseSync(),
             pbxBuildConfigurationSection = myProj.pbxXCBuildConfigurationSection(),
-            xcConfigurationList = myProj.addXCConfigurationList([debugConfiguration, releaseConfiguration], 'Release', 'XCConfigurationList Comment'),
-            xcConfigurationListConfigurations = xcConfigurationList.xcConfigurationList.buildConfigurations;
+            xcConfigurationList = myProj.addXCConfigurationList(
+                [debugConfiguration, releaseConfiguration],
+                'Release',
+                'XCConfigurationList Comment'
+            ),
+            xcConfigurationListConfigurations =
+                xcConfigurationList.xcConfigurationList.buildConfigurations;
 
-        for (var index = 0; index < xcConfigurationListConfigurations.length; index++) {
+        for (
+            var index = 0;
+            index < xcConfigurationListConfigurations.length;
+            index++
+        ) {
             var configuration = xcConfigurationListConfigurations[index];
-            test.ok(pbxBuildConfigurationSection[configuration.value + '_comment']);
+            test.ok(
+                pbxBuildConfigurationSection[configuration.value + '_comment']
+            );
         }
 
         test.done();
     }
-}
+};

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var jsonProject = require('./fixtures/full-project')
+var jsonProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(jsonProject),
     path = require('path'),
     pbx = require('../lib/pbxProject'),

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -21,43 +21,49 @@ var jsonProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.'),
-    singleDataModelFilePath = __dirname + '/fixtures/single-data-model.xcdatamodeld',
-    multipleDataModelFilePath = __dirname + '/fixtures/multiple-data-model.xcdatamodeld';
+    singleDataModelFilePath =
+        __dirname + '/fixtures/single-data-model.xcdatamodeld',
+    multipleDataModelFilePath =
+        __dirname + '/fixtures/multiple-data-model.xcdatamodeld';
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.dataModelDocument = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.ok(newFile.uuid);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
     'should set an optional target on the pbxFile': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath, undefined, { target: target }),
+        var newFile = proj.addDataModelDocument(
+                singleDataModelFilePath,
+                undefined,
+                { target: target }
+            ),
             target = proj.findTargetKey('TestApp');
 
         test.equal(newFile.target, target);
-        test.done()
+        test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath),
@@ -70,7 +76,9 @@ exports.dataModelDocument = {
 
         test.done();
     },
-    'should populate the PBXFileReference section with 2 fields for single model document': function (test) {
+    'should populate the PBXFileReference section with 2 fields for single model document': function (
+        test
+    ) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -81,7 +89,9 @@ exports.dataModelDocument = {
 
         test.done();
     },
-    'should populate the PBXFileReference section with 2 fields for each model of a model document': function (test) {
+    'should populate the PBXFileReference section with 2 fields for each model of a model document': function (
+        test
+    ) {
         var newFile = proj.addDataModelDocument(multipleDataModelFilePath),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -96,11 +106,14 @@ exports.dataModelDocument = {
     },
     'should add to resources group by default': function (test) {
         var newFile = proj.addDataModelDocument(singleDataModelFilePath);
-            groupChildren = proj.pbxGroupByName('Resources').children,
-            found = false;
+        (groupChildren = proj.pbxGroupByName('Resources').children),
+        (found = false);
 
         for (var index in groupChildren) {
-            if (groupChildren[index].comment === 'single-data-model.xcdatamodeld') {
+            if (
+                groupChildren[index].comment ===
+                'single-data-model.xcdatamodeld'
+            ) {
                 found = true;
                 break;
             }
@@ -110,12 +123,18 @@ exports.dataModelDocument = {
     },
     'should add to group specified by key': function (test) {
         var group = 'Frameworks',
-            newFile = proj.addDataModelDocument(singleDataModelFilePath, proj.findPBXGroupKey({ name: group }));
-            groupChildren = proj.pbxGroupByName(group).children;
+            newFile = proj.addDataModelDocument(
+                singleDataModelFilePath,
+                proj.findPBXGroupKey({ name: group })
+            );
+        groupChildren = proj.pbxGroupByName(group).children;
 
         var found = false;
         for (var index in groupChildren) {
-            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+            if (
+                groupChildren[index].comment ===
+                path.basename(singleDataModelFilePath)
+            ) {
                 found = true;
                 break;
             }
@@ -125,12 +144,18 @@ exports.dataModelDocument = {
     },
     'should add to group specified by name': function (test) {
         var group = 'Frameworks',
-            newFile = proj.addDataModelDocument(singleDataModelFilePath, group);
-            groupChildren = proj.pbxGroupByName(group).children;
+            newFile = proj.addDataModelDocument(
+                singleDataModelFilePath,
+                group
+            );
+        groupChildren = proj.pbxGroupByName(group).children;
 
         var found = false;
         for (var index in groupChildren) {
-            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+            if (
+                groupChildren[index].comment ===
+                path.basename(singleDataModelFilePath)
+            ) {
                 found = true;
                 break;
             }
@@ -157,7 +182,10 @@ exports.dataModelDocument = {
             xcVersionGroupSection = proj.xcVersionGroupSection(),
             commentKey = newFile.fileRef + '_comment';
 
-        test.equal(xcVersionGroupSection[commentKey], path.basename(singleDataModelFilePath));
+        test.equal(
+            xcVersionGroupSection[commentKey],
+            path.basename(singleDataModelFilePath)
+        );
         test.done();
     },
     'should add the XCVersionGroup object correctly': function (test) {
@@ -166,14 +194,29 @@ exports.dataModelDocument = {
             xcVersionGroupEntry = xcVersionGroupSection[newFile.fileRef];
 
         test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
-        test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
-        test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
-        test.equal(xcVersionGroupEntry.name, path.basename(singleDataModelFilePath));
+        test.equal(
+            xcVersionGroupEntry.children[0],
+            newFile.models[0].fileRef
+        );
+        test.equal(
+            xcVersionGroupEntry.currentVersion,
+            newFile.currentModel.fileRef
+        );
+        test.equal(
+            xcVersionGroupEntry.name,
+            path.basename(singleDataModelFilePath)
+        );
         // Need to validate against normalized path, since paths should contain forward slash on OSX
-        test.equal(xcVersionGroupEntry.path, singleDataModelFilePath.replace(/\\/g, '/'));
+        test.equal(
+            xcVersionGroupEntry.path,
+            singleDataModelFilePath.replace(/\\/g, '/')
+        );
         test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
-        test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');
+        test.equal(
+            xcVersionGroupEntry.versionGroupType,
+            'wrapper.xcdatamodel'
+        );
 
         test.done();
     }
-}
+};

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -15,15 +15,15 @@
  under the License.
  */
 
-var jsonProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(jsonProject),
-    path = require('path'),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.'),
-    singleDataModelFilePath =
-        __dirname + '/fixtures/single-data-model.xcdatamodeld',
-    multipleDataModelFilePath =
+const jsonProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(jsonProject);
+const path = require('path');
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
+const singleDataModelFilePath =
+        __dirname + '/fixtures/single-data-model.xcdatamodeld';
+const multipleDataModelFilePath =
         __dirname + '/fixtures/multiple-data-model.xcdatamodeld';
 
 function cleanHash () {
@@ -37,38 +37,39 @@ exports.setUp = function (callback) {
 
 exports.dataModelDocument = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.ok(newFile.uuid);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
 
         test.ok(newFile.fileRef);
         test.done();
     },
     'should set an optional target on the pbxFile': function (test) {
-        var newFile = proj.addDataModelDocument(
-                singleDataModelFilePath,
-                undefined,
-                { target: target }
-            ),
-            target = proj.findTargetKey('TestApp');
+        const target = proj.findTargetKey('TestApp');
+
+        const newFile = proj.addDataModelDocument(
+            singleDataModelFilePath,
+            undefined,
+            { target: target }
+        );
 
         test.equal(newFile.target, target);
         test.done();
     },
     'should populate the PBXBuildFile section with 2 fields': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const buildFileSection = proj.pbxBuildFileSection();
+        const bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(59 + 1, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
@@ -79,9 +80,9 @@ exports.dataModelDocument = {
     'should populate the PBXFileReference section with 2 fields for single model document': function (
         test
     ) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66 + 2, frsLength);
         test.ok(fileRefSection[newFile.models[0].fileRef]);
@@ -92,9 +93,9 @@ exports.dataModelDocument = {
     'should populate the PBXFileReference section with 2 fields for each model of a model document': function (
         test
     ) {
-        var newFile = proj.addDataModelDocument(multipleDataModelFilePath),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addDataModelDocument(multipleDataModelFilePath);
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66 + 2 * 2, frsLength);
         test.ok(fileRefSection[newFile.models[0].fileRef]);
@@ -105,11 +106,11 @@ exports.dataModelDocument = {
         test.done();
     },
     'should add to resources group by default': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
         (groupChildren = proj.pbxGroupByName('Resources').children),
         (found = false);
 
-        for (var index in groupChildren) {
+        for (const index in groupChildren) {
             if (
                 groupChildren[index].comment ===
                 'single-data-model.xcdatamodeld'
@@ -122,15 +123,15 @@ exports.dataModelDocument = {
         test.done();
     },
     'should add to group specified by key': function (test) {
-        var group = 'Frameworks',
-            newFile = proj.addDataModelDocument(
-                singleDataModelFilePath,
-                proj.findPBXGroupKey({ name: group })
-            );
+        const group = 'Frameworks';
+        const newFile = proj.addDataModelDocument(
+            singleDataModelFilePath,
+            proj.findPBXGroupKey({ name: group })
+        );
         groupChildren = proj.pbxGroupByName(group).children;
 
-        var found = false;
-        for (var index in groupChildren) {
+        let found = false;
+        for (const index in groupChildren) {
             if (
                 groupChildren[index].comment ===
                 path.basename(singleDataModelFilePath)
@@ -143,15 +144,15 @@ exports.dataModelDocument = {
         test.done();
     },
     'should add to group specified by name': function (test) {
-        var group = 'Frameworks',
-            newFile = proj.addDataModelDocument(
-                singleDataModelFilePath,
-                group
-            );
+        const group = 'Frameworks';
+        const newFile = proj.addDataModelDocument(
+            singleDataModelFilePath,
+            group
+        );
         groupChildren = proj.pbxGroupByName(group).children;
 
-        var found = false;
-        for (var index in groupChildren) {
+        let found = false;
+        for (const index in groupChildren) {
             if (
                 groupChildren[index].comment ===
                 path.basename(singleDataModelFilePath)
@@ -164,23 +165,23 @@ exports.dataModelDocument = {
         test.done();
     },
     'should add to the PBXSourcesBuildPhase': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            sources = proj.pbxSourcesBuildPhaseObj();
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const sources = proj.pbxSourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 2 + 1);
         test.done();
     },
     'should create a XCVersionGroup section': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            xcVersionGroupSection = proj.xcVersionGroupSection();
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const xcVersionGroupSection = proj.xcVersionGroupSection();
 
         test.ok(xcVersionGroupSection[newFile.fileRef]);
         test.done();
     },
     'should populate the XCVersionGroup comment correctly': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            xcVersionGroupSection = proj.xcVersionGroupSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const xcVersionGroupSection = proj.xcVersionGroupSection();
+        const commentKey = newFile.fileRef + '_comment';
 
         test.equal(
             xcVersionGroupSection[commentKey],
@@ -189,9 +190,9 @@ exports.dataModelDocument = {
         test.done();
     },
     'should add the XCVersionGroup object correctly': function (test) {
-        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
-            xcVersionGroupSection = proj.xcVersionGroupSection(),
-            xcVersionGroupEntry = xcVersionGroupSection[newFile.fileRef];
+        const newFile = proj.addDataModelDocument(singleDataModelFilePath);
+        const xcVersionGroupSection = proj.xcVersionGroupSection();
+        const xcVersionGroupEntry = xcVersionGroupSection[newFile.fileRef];
 
         test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
         test.equal(

--- a/test/group.js
+++ b/test/group.js
@@ -20,7 +20,7 @@ var pbx = require('../lib/pbxProject'),
     project,
     projectHash;
 
-var findChildInGroup = function(obj, target) {
+var findChildInGroup = function (obj, target) {
     var found = false;
 
     for (var i = 0, j = obj.children.length; i < j; i++) {
@@ -31,9 +31,9 @@ var findChildInGroup = function(obj, target) {
     }
 
     return found;
-}
+};
 
-var findFileByUUID = function(obj, target) {
+var findFileByUUID = function (obj, target) {
     var found = false;
 
     for (var k = 0, l = obj.files.length; k < l; k++) {
@@ -44,9 +44,9 @@ var findFileByUUID = function(obj, target) {
     }
 
     return found;
-}
+};
 
-var findByFileRef = function(obj, target) {
+var findByFileRef = function (obj, target) {
     var found = false;
 
     for (var property in obj) {
@@ -58,9 +58,9 @@ var findByFileRef = function(obj, target) {
         }
     }
     return found;
-}
+};
 
-var findByName = function(obj, target) {
+var findByName = function (obj, target) {
     var found = false;
     for (var property in obj) {
         if (!/comment/.test(property)) {
@@ -71,39 +71,38 @@ var findByName = function(obj, target) {
         }
     }
     return found;
-}
+};
 
-exports.setUp = function(callback) {
+exports.setUp = function (callback) {
     project = new pbx('test/parser/projects/group.pbxproj');
     projectHash = project.parseSync();
     callback();
-}
+};
 
 exports.getGroupByKey = {
-    'should return PBXGroup for Classes': function(test) {
-        var groupKey = project.findPBXGroupKey({name: 'Classes'});
+    'should return PBXGroup for Classes': function (test) {
+        var groupKey = project.findPBXGroupKey({ name: 'Classes' });
         var group = project.getPBXGroupByKey(groupKey);
         test.ok(group.name === 'Classes');
         test.done();
     },
-    'should return PBXGroup for Plugins': function(test) {
-        var groupKey = project.findPBXGroupKey({name: 'Plugins'});
+    'should return PBXGroup for Plugins': function (test) {
+        var groupKey = project.findPBXGroupKey({ name: 'Plugins' });
         var group = project.getPBXGroupByKey(groupKey);
         test.ok(group.name === 'Plugins');
         test.done();
     }
-}
+};
 
 exports.createGroup = {
-    'should create a new Test Group': function(test) {
+    'should create a new Test Group': function (test) {
         var found = false;
         var groups = project.getPBXObject('PBXGroup');
 
         var found = findByName(groups, 'Test');
         test.ok(found === false);
 
-
-        var group = project.findPBXGroupKey({name:'Test'});
+        var group = project.findPBXGroupKey({ name: 'Test' });
         test.ok(group === undefined);
 
         project.pbxCreateGroup('Test', 'Test');
@@ -112,18 +111,21 @@ exports.createGroup = {
         found = findByName(groups, 'Test');
         test.ok(found === true);
 
-        group = project.findPBXGroupKey({name:'Test'});
+        group = project.findPBXGroupKey({ name: 'Test' });
         test.ok(typeof group === 'string');
         test.done();
     }
-}
+};
 
 exports.findGroupKey = {
-    'should return a valid group key':function(test) {
-        var keyByName = project.findPBXGroupKey({ name: 'Classes'});
-        var keyByPath = project.findPBXGroupKey({ path: 'icons'});
-        var keyByPathName = project.findPBXGroupKey({ path: '"HelloCordova/Plugins"', name: 'Plugins'});
-        var nonExistingKey = project.findPBXGroupKey({ name: 'Foo'});
+    'should return a valid group key': function (test) {
+        var keyByName = project.findPBXGroupKey({ name: 'Classes' });
+        var keyByPath = project.findPBXGroupKey({ path: 'icons' });
+        var keyByPathName = project.findPBXGroupKey({
+            path: '"HelloCordova/Plugins"',
+            name: 'Plugins'
+        });
+        var nonExistingKey = project.findPBXGroupKey({ name: 'Foo' });
 
         test.ok(keyByName === '080E96DDFE201D6D7F000001');
         test.ok(keyByPath === '308D052D1370CCF300D202BF');
@@ -132,12 +134,14 @@ exports.findGroupKey = {
 
         test.done();
     }
-}
+};
 
 exports.addGroupToGroup = {
-    'should create a new test group then add group to Classes group': function(test) {
+    'should create a new test group then add group to Classes group': function (
+        test
+    ) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
-        var classesKey = project.findPBXGroupKey({name: 'Classes'});
+        var classesKey = project.findPBXGroupKey({ name: 'Classes' });
         project.addToPbxGroup(testKey, classesKey);
 
         var classesGroup = project.getPBXGroupByKey(classesKey);
@@ -153,11 +157,13 @@ exports.addGroupToGroup = {
 
         test.done();
     }
-}
+};
 
 exports.predefinedPbxGroups = {
-    setUp: function(callback) {
-        project = new pbx('test/parser/projects/empty-groups.pbxproj').parseSync();
+    setUp: function (callback) {
+        project = new pbx(
+            'test/parser/projects/empty-groups.pbxproj'
+        ).parseSync();
 
         this.file = new pbxFile('some-file.m');
         this.file.fileRef = project.generateUuid();
@@ -166,198 +172,289 @@ exports.predefinedPbxGroups = {
         callback();
     },
 
-    'should add a file to "Plugins" group': function(test) {
+    'should add a file to "Plugins" group': function (test) {
         project.addToPluginsPbxGroup(this.file);
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Plugins'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Plugins'),
+            this.file.fileRef
+        );
         test.ok(foundInGroup);
         test.done();
     },
 
-    'should remove a file from "Plugins" group': function(test) {
+    'should remove a file from "Plugins" group': function (test) {
         project.addToPluginsPbxGroup(this.file);
         project.removeFromPluginsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Plugins'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Plugins'),
+            this.file.fileRef
+        );
         test.ok(!foundInGroup);
         test.done();
     },
 
-    'should add a file to "Resources" group': function(test) {
+    'should add a file to "Resources" group': function (test) {
         project.addToResourcesPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Resources'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Resources'),
+            this.file.fileRef
+        );
         test.ok(foundInGroup);
         test.done();
     },
 
-    'should remove a file from "Resources" group': function(test) {
+    'should remove a file from "Resources" group': function (test) {
         project.addToResourcesPbxGroup(this.file);
         project.removeFromResourcesPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Resources'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Resources'),
+            this.file.fileRef
+        );
         test.ok(!foundInGroup);
         test.done();
     },
 
-    'should add a file to "Frameworks" group': function(test) {
+    'should add a file to "Frameworks" group': function (test) {
         project.addToFrameworksPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Frameworks'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Frameworks'),
+            this.file.fileRef
+        );
         test.ok(foundInGroup);
         test.done();
     },
 
-    'should remove a file from "Frameworks" group': function(test) {
+    'should remove a file from "Frameworks" group': function (test) {
         project.addToFrameworksPbxGroup(this.file);
         project.removeFromFrameworksPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Frameworks'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Frameworks'),
+            this.file.fileRef
+        );
         test.ok(!foundInGroup);
         test.done();
     },
 
-    'should add a file to "Products" group': function(test) {
+    'should add a file to "Products" group': function (test) {
         project.addToProductsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Products'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Products'),
+            this.file.fileRef
+        );
         test.ok(foundInGroup);
         test.done();
     },
 
-    'should remove a file from "Products" group': function(test) {
+    'should remove a file from "Products" group': function (test) {
         project.addToProductsPbxGroup(this.file);
         project.removeFromProductsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(project.pbxGroupByName('Products'), this.file.fileRef);
+        var foundInGroup = findChildInGroup(
+            project.pbxGroupByName('Products'),
+            this.file.fileRef
+        );
         test.ok(!foundInGroup);
         test.done();
     }
 };
 
 exports.addSourceFileToGroup = {
-    'should create group + add source file' : function(test) {
+    'should create group + add source file': function (test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        var foundInBuildFileSection = findByFileRef(
+            project.pbxBuildFileSection(),
+            file.fileRef
+        );
         test.ok(foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        var foundInBuildPhase = findFileByUUID(
+            project.pbxSourcesBuildPhaseObj(),
+            file.uuid
+        );
         test.ok(foundInBuildPhase);
 
         test.done();
     }
-}
+};
 
 exports.removeSourceFileFromGroup = {
-    'should create group + add source file then remove source file' : function(test) {
+    'should create group + add source file then remove source file': function (
+        test
+    ) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        var foundInBuildFileSection = findByFileRef(
+            project.pbxBuildFileSection(),
+            file.fileRef
+        );
         test.ok(foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        var foundInBuildPhase = findFileByUUID(
+            project.pbxSourcesBuildPhaseObj(),
+            file.uuid
+        );
         test.ok(foundInBuildPhase);
 
         project.removeSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(!foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        var foundInBuildFileSection = findByFileRef(
+            project.pbxBuildFileSection(),
+            file.fileRef
+        );
         test.ok(!foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        var foundInBuildPhase = findFileByUUID(
+            project.pbxSourcesBuildPhaseObj(),
+            file.uuid
+        );
         test.ok(!foundInBuildPhase);
 
         test.done();
     }
-}
+};
 
 exports.addHeaderFileToGroup = {
-    'should create group + add header file' : function(test) {
+    'should create group + add header file': function (test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
         test.done();
     }
-}
+};
 
 exports.removeHeaderFileFromGroup = {
-    'should create group + add source file then remove header file' : function(test) {
+    'should create group + add source file then remove header file': function (
+        test
+    ) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
         project.removeHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(!foundInGroup);
 
         test.done();
     }
-}
+};
 
 exports.addResourceFileToGroup = {
-    'should add resource file (PNG) to the splash group' : function(test) {
+    'should add resource file (PNG) to the splash group': function (test) {
+        var testKey = project.findPBXGroupKey({ path: 'splash' });
+        var file = project.addResourceFile(
+            'DefaultTest-667h.png',
+            {},
+            testKey
+        );
 
-        var testKey = project.findPBXGroupKey({path:'splash'});
-        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
-
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
         test.done();
     }
-}
+};
 
 exports.removeResourceFileFromGroup = {
-    'should add resource file (PNG) then remove resource file from splash group' : function(test) {
-        var testKey = project.findPBXGroupKey({path:'splash'});
-        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
+    'should add resource file (PNG) then remove resource file from splash group': function (
+        test
+    ) {
+        var testKey = project.findPBXGroupKey({ path: 'splash' });
+        var file = project.addResourceFile(
+            'DefaultTest-667h.png',
+            {},
+            testKey
+        );
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
         project.removeResourceFile('DefaultTest-667h.png', {}, testKey);
 
-        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(!foundInGroup);
 
         test.done();
     }
-}
+};
 
 exports.retrieveBuildPropertyForBuild = {
-    'should retrieve valid build property ':function(test) {
-        var releaseTargetedDeviceFamily = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Release');
-        var debugTargetedDeviceFamily = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Debug');
+    'should retrieve valid build property ': function (test) {
+        var releaseTargetedDeviceFamily = project.getBuildProperty(
+            'TARGETED_DEVICE_FAMILY',
+            'Release'
+        );
+        var debugTargetedDeviceFamily = project.getBuildProperty(
+            'TARGETED_DEVICE_FAMILY',
+            'Debug'
+        );
         var nonExistingProperty = project.getBuildProperty('FOO', 'Debug');
-        var nonExistingBuild = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Foo');
+        var nonExistingBuild = project.getBuildProperty(
+            'TARGETED_DEVICE_FAMILY',
+            'Foo'
+        );
 
         test.equal(releaseTargetedDeviceFamily, '"1,2"');
-        test.equal(debugTargetedDeviceFamily,'"1"');
+        test.equal(debugTargetedDeviceFamily, '"1"');
         test.equal(nonExistingProperty, undefined);
         test.equal(nonExistingBuild, undefined);
 
         test.done();
     }
-}
+};
 
 exports.retrieveBuildConfigByName = {
-    'should retrieve valid build config':function(test) {
+    'should retrieve valid build config': function (test) {
         var releaseBuildConfig = project.getBuildConfigByName('Release');
         for (var property in releaseBuildConfig) {
             var value = releaseBuildConfig[property];
@@ -375,7 +472,7 @@ exports.retrieveBuildConfigByName = {
 
         test.done();
     }
-}
+};
 
 /* This proves the issue in 0.6.7
 exports.validatePropReplaceException = {
@@ -393,22 +490,26 @@ exports.validatePropReplaceException = {
 */
 
 exports.validatePropReplaceFix = {
-    'should create build configuration for VALID_ARCHS when none existed' : function(test) {
+    'should create build configuration for VALID_ARCHS when none existed': function (
+        test
+    ) {
         project.updateBuildProperty('VALID_ARCHS', '"armv7 armv7s"', 'Debug');
         test.done();
     }
-}
+};
 
 exports.validateHasFile = {
-    'should return true for has file MainViewController.m': function(test) {
+    'should return true for has file MainViewController.m': function (test) {
         var result = project.hasFile('MainViewController.m');
-        test.ok(result.path == "MainViewController.m");
+        test.ok(result.path == 'MainViewController.m');
         test.done();
     }
-}
+};
 
 exports.testWritingPBXProject = {
-    'should successfully write to PBXProject TargetAttributes': function(test) {
+    'should successfully write to PBXProject TargetAttributes': function (
+        test
+    ) {
         var pbxProjectObj = project.getPBXObject('PBXProject');
         var pbxProject;
         for (var property in pbxProjectObj) {
@@ -419,7 +520,7 @@ exports.testWritingPBXProject = {
 
         var target;
         var projectTargets = pbxProject.targets;
-        for (var i = 0, j = pbxProject.targets.length; i < j; i++ ) {
+        for (var i = 0, j = pbxProject.targets.length; i < j; i++) {
             target = pbxProject.targets[i].value;
         }
 
@@ -427,13 +528,13 @@ exports.testWritingPBXProject = {
         pbxProject.attributes.TargetAttributes[target] = {
             DevelopmentTeam: 'N6X4RJZZ5D',
             SystemCapabilities: {
-                "com.apple.BackgroundModes": {
-                    enabled : 0
+                'com.apple.BackgroundModes': {
+                    enabled: 0
                 },
-                "com.apple.DataProtection" : {
-                    enabled : 0
+                'com.apple.DataProtection': {
+                    enabled: 0
                 },
-                "com.apple.Keychain" : {
+                'com.apple.Keychain': {
                     enabled: 1
                 }
             }
@@ -443,14 +544,18 @@ exports.testWritingPBXProject = {
 
         test.done();
     },
-    'should add target attribute to PBXProject TargetAttributes': function(test) {
+    'should add target attribute to PBXProject TargetAttributes': function (
+        test
+    ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
         var output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
 
         test.done();
     },
-    'should change target attribute at PBXProject TargetAttributes': function(test) {
+    'should change target attribute at PBXProject TargetAttributes': function (
+        test
+    ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
         var output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
@@ -458,11 +563,16 @@ exports.testWritingPBXProject = {
         project.addTargetAttribute('ProvisioningStyle', 'Automatic');
         output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g), null);
-        test.equal(output.match(/ProvisioningStyle\s*=\s*Automatic/g).length, 1);
+        test.equal(
+            output.match(/ProvisioningStyle\s*=\s*Automatic/g).length,
+            1
+        );
 
         test.done();
     },
-    'should remove target attribute from PBXProject TargetAttributes': function(test) {
+    'should remove target attribute from PBXProject TargetAttributes': function (
+        test
+    ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
         var output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
@@ -473,4 +583,4 @@ exports.testWritingPBXProject = {
 
         test.done();
     }
-}
+};

--- a/test/group.js
+++ b/test/group.js
@@ -15,15 +15,15 @@
  under the License.
  */
 
-var pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    project,
-    projectHash;
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+let project;
+let projectHash;
 
-var findChildInGroup = function (obj, target) {
-    var found = false;
+const findChildInGroup = function (obj, target) {
+    let found = false;
 
-    for (var i = 0, j = obj.children.length; i < j; i++) {
+    for (let i = 0, j = obj.children.length; i < j; i++) {
         if (obj.children[i].value === target) {
             found = true;
             break;
@@ -33,10 +33,10 @@ var findChildInGroup = function (obj, target) {
     return found;
 };
 
-var findFileByUUID = function (obj, target) {
-    var found = false;
+const findFileByUUID = function (obj, target) {
+    let found = false;
 
-    for (var k = 0, l = obj.files.length; k < l; k++) {
+    for (let k = 0, l = obj.files.length; k < l; k++) {
         if (obj.files[k].value === target) {
             found = true;
             break;
@@ -46,10 +46,10 @@ var findFileByUUID = function (obj, target) {
     return found;
 };
 
-var findByFileRef = function (obj, target) {
-    var found = false;
+const findByFileRef = function (obj, target) {
+    let found = false;
 
-    for (var property in obj) {
+    for (const property in obj) {
         if (!/comment/.test(property)) {
             if (obj[property].fileRef === target) {
                 found = true;
@@ -60,11 +60,11 @@ var findByFileRef = function (obj, target) {
     return found;
 };
 
-var findByName = function (obj, target) {
-    var found = false;
-    for (var property in obj) {
+const findByName = function (obj, target) {
+    let found = false;
+    for (const property in obj) {
         if (!/comment/.test(property)) {
-            var value = obj[property];
+            const value = obj[property];
             if (value.name === target) {
                 found = true;
             }
@@ -81,14 +81,14 @@ exports.setUp = function (callback) {
 
 exports.getGroupByKey = {
     'should return PBXGroup for Classes': function (test) {
-        var groupKey = project.findPBXGroupKey({ name: 'Classes' });
-        var group = project.getPBXGroupByKey(groupKey);
+        const groupKey = project.findPBXGroupKey({ name: 'Classes' });
+        const group = project.getPBXGroupByKey(groupKey);
         test.ok(group.name === 'Classes');
         test.done();
     },
     'should return PBXGroup for Plugins': function (test) {
-        var groupKey = project.findPBXGroupKey({ name: 'Plugins' });
-        var group = project.getPBXGroupByKey(groupKey);
+        const groupKey = project.findPBXGroupKey({ name: 'Plugins' });
+        const group = project.getPBXGroupByKey(groupKey);
         test.ok(group.name === 'Plugins');
         test.done();
     }
@@ -96,13 +96,13 @@ exports.getGroupByKey = {
 
 exports.createGroup = {
     'should create a new Test Group': function (test) {
-        var found = false;
-        var groups = project.getPBXObject('PBXGroup');
+        let found = false;
+        let groups = project.getPBXObject('PBXGroup');
 
-        var found = findByName(groups, 'Test');
+        found = findByName(groups, 'Test');
         test.ok(found === false);
 
-        var group = project.findPBXGroupKey({ name: 'Test' });
+        let group = project.findPBXGroupKey({ name: 'Test' });
         test.ok(group === undefined);
 
         project.pbxCreateGroup('Test', 'Test');
@@ -119,13 +119,13 @@ exports.createGroup = {
 
 exports.findGroupKey = {
     'should return a valid group key': function (test) {
-        var keyByName = project.findPBXGroupKey({ name: 'Classes' });
-        var keyByPath = project.findPBXGroupKey({ path: 'icons' });
-        var keyByPathName = project.findPBXGroupKey({
+        const keyByName = project.findPBXGroupKey({ name: 'Classes' });
+        const keyByPath = project.findPBXGroupKey({ path: 'icons' });
+        const keyByPathName = project.findPBXGroupKey({
             path: '"HelloCordova/Plugins"',
             name: 'Plugins'
         });
-        var nonExistingKey = project.findPBXGroupKey({ name: 'Foo' });
+        const nonExistingKey = project.findPBXGroupKey({ name: 'Foo' });
 
         test.ok(keyByName === '080E96DDFE201D6D7F000001');
         test.ok(keyByPath === '308D052D1370CCF300D202BF');
@@ -140,14 +140,14 @@ exports.addGroupToGroup = {
     'should create a new test group then add group to Classes group': function (
         test
     ) {
-        var testKey = project.pbxCreateGroup('Test', 'Test');
-        var classesKey = project.findPBXGroupKey({ name: 'Classes' });
+        const testKey = project.pbxCreateGroup('Test', 'Test');
+        const classesKey = project.findPBXGroupKey({ name: 'Classes' });
         project.addToPbxGroup(testKey, classesKey);
 
-        var classesGroup = project.getPBXGroupByKey(classesKey);
-        var foundTestGroup = false;
-        for (var i = 0, j = classesGroup.children.length; i < j; i++) {
-            var child = classesGroup.children[i];
+        const classesGroup = project.getPBXGroupByKey(classesKey);
+        let foundTestGroup = false;
+        for (let i = 0, j = classesGroup.children.length; i < j; i++) {
+            const child = classesGroup.children[i];
             if (child.value === testKey && child.comment === 'Test') {
                 foundTestGroup = true;
             }
@@ -174,7 +174,7 @@ exports.predefinedPbxGroups = {
 
     'should add a file to "Plugins" group': function (test) {
         project.addToPluginsPbxGroup(this.file);
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Plugins'),
             this.file.fileRef
         );
@@ -186,7 +186,7 @@ exports.predefinedPbxGroups = {
         project.addToPluginsPbxGroup(this.file);
         project.removeFromPluginsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Plugins'),
             this.file.fileRef
         );
@@ -197,7 +197,7 @@ exports.predefinedPbxGroups = {
     'should add a file to "Resources" group': function (test) {
         project.addToResourcesPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Resources'),
             this.file.fileRef
         );
@@ -209,7 +209,7 @@ exports.predefinedPbxGroups = {
         project.addToResourcesPbxGroup(this.file);
         project.removeFromResourcesPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Resources'),
             this.file.fileRef
         );
@@ -220,7 +220,7 @@ exports.predefinedPbxGroups = {
     'should add a file to "Frameworks" group': function (test) {
         project.addToFrameworksPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Frameworks'),
             this.file.fileRef
         );
@@ -232,7 +232,7 @@ exports.predefinedPbxGroups = {
         project.addToFrameworksPbxGroup(this.file);
         project.removeFromFrameworksPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Frameworks'),
             this.file.fileRef
         );
@@ -243,7 +243,7 @@ exports.predefinedPbxGroups = {
     'should add a file to "Products" group': function (test) {
         project.addToProductsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Products'),
             this.file.fileRef
         );
@@ -255,7 +255,7 @@ exports.predefinedPbxGroups = {
         project.addToProductsPbxGroup(this.file);
         project.removeFromProductsPbxGroup(this.file);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.pbxGroupByName('Products'),
             this.file.fileRef
         );
@@ -266,22 +266,22 @@ exports.predefinedPbxGroups = {
 
 exports.addSourceFileToGroup = {
     'should create group + add source file': function (test) {
-        var testKey = project.pbxCreateGroup('Test', 'Test');
-        var file = project.addSourceFile('Notifications.m', {}, testKey);
+        const testKey = project.pbxCreateGroup('Test', 'Test');
+        const file = project.addSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
         test.ok(foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(
+        const foundInBuildFileSection = findByFileRef(
             project.pbxBuildFileSection(),
             file.fileRef
         );
         test.ok(foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(
+        const foundInBuildPhase = findFileByUUID(
             project.pbxSourcesBuildPhaseObj(),
             file.uuid
         );
@@ -295,22 +295,22 @@ exports.removeSourceFileFromGroup = {
     'should create group + add source file then remove source file': function (
         test
     ) {
-        var testKey = project.pbxCreateGroup('Test', 'Test');
-        var file = project.addSourceFile('Notifications.m', {}, testKey);
+        const testKey = project.pbxCreateGroup('Test', 'Test');
+        const file = project.addSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        let foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
         test.ok(foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(
+        let foundInBuildFileSection = findByFileRef(
             project.pbxBuildFileSection(),
             file.fileRef
         );
         test.ok(foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(
+        let foundInBuildPhase = findFileByUUID(
             project.pbxSourcesBuildPhaseObj(),
             file.uuid
         );
@@ -318,19 +318,19 @@ exports.removeSourceFileFromGroup = {
 
         project.removeSourceFile('Notifications.m', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
         test.ok(!foundInGroup);
 
-        var foundInBuildFileSection = findByFileRef(
+        foundInBuildFileSection = findByFileRef(
             project.pbxBuildFileSection(),
             file.fileRef
         );
         test.ok(!foundInBuildFileSection);
 
-        var foundInBuildPhase = findFileByUUID(
+        foundInBuildPhase = findFileByUUID(
             project.pbxSourcesBuildPhaseObj(),
             file.uuid
         );
@@ -342,10 +342,10 @@ exports.removeSourceFileFromGroup = {
 
 exports.addHeaderFileToGroup = {
     'should create group + add header file': function (test) {
-        var testKey = project.pbxCreateGroup('Test', 'Test');
-        var file = project.addHeaderFile('Notifications.h', {}, testKey);
+        const testKey = project.pbxCreateGroup('Test', 'Test');
+        const file = project.addHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -359,10 +359,10 @@ exports.removeHeaderFileFromGroup = {
     'should create group + add source file then remove header file': function (
         test
     ) {
-        var testKey = project.pbxCreateGroup('Test', 'Test');
-        var file = project.addHeaderFile('Notifications.h', {}, testKey);
+        const testKey = project.pbxCreateGroup('Test', 'Test');
+        const file = project.addHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        let foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -370,7 +370,7 @@ exports.removeHeaderFileFromGroup = {
 
         project.removeHeaderFile('Notifications.h', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -382,14 +382,14 @@ exports.removeHeaderFileFromGroup = {
 
 exports.addResourceFileToGroup = {
     'should add resource file (PNG) to the splash group': function (test) {
-        var testKey = project.findPBXGroupKey({ path: 'splash' });
-        var file = project.addResourceFile(
+        const testKey = project.findPBXGroupKey({ path: 'splash' });
+        const file = project.addResourceFile(
             'DefaultTest-667h.png',
             {},
             testKey
         );
 
-        var foundInGroup = findChildInGroup(
+        const foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -403,14 +403,14 @@ exports.removeResourceFileFromGroup = {
     'should add resource file (PNG) then remove resource file from splash group': function (
         test
     ) {
-        var testKey = project.findPBXGroupKey({ path: 'splash' });
-        var file = project.addResourceFile(
+        const testKey = project.findPBXGroupKey({ path: 'splash' });
+        const file = project.addResourceFile(
             'DefaultTest-667h.png',
             {},
             testKey
         );
 
-        var foundInGroup = findChildInGroup(
+        let foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -418,7 +418,7 @@ exports.removeResourceFileFromGroup = {
 
         project.removeResourceFile('DefaultTest-667h.png', {}, testKey);
 
-        var foundInGroup = findChildInGroup(
+        foundInGroup = findChildInGroup(
             project.getPBXGroupByKey(testKey),
             file.fileRef
         );
@@ -430,16 +430,16 @@ exports.removeResourceFileFromGroup = {
 
 exports.retrieveBuildPropertyForBuild = {
     'should retrieve valid build property ': function (test) {
-        var releaseTargetedDeviceFamily = project.getBuildProperty(
+        const releaseTargetedDeviceFamily = project.getBuildProperty(
             'TARGETED_DEVICE_FAMILY',
             'Release'
         );
-        var debugTargetedDeviceFamily = project.getBuildProperty(
+        const debugTargetedDeviceFamily = project.getBuildProperty(
             'TARGETED_DEVICE_FAMILY',
             'Debug'
         );
-        var nonExistingProperty = project.getBuildProperty('FOO', 'Debug');
-        var nonExistingBuild = project.getBuildProperty(
+        const nonExistingProperty = project.getBuildProperty('FOO', 'Debug');
+        const nonExistingBuild = project.getBuildProperty(
             'TARGETED_DEVICE_FAMILY',
             'Foo'
         );
@@ -455,19 +455,19 @@ exports.retrieveBuildPropertyForBuild = {
 
 exports.retrieveBuildConfigByName = {
     'should retrieve valid build config': function (test) {
-        var releaseBuildConfig = project.getBuildConfigByName('Release');
-        for (var property in releaseBuildConfig) {
-            var value = releaseBuildConfig[property];
+        const releaseBuildConfig = project.getBuildConfigByName('Release');
+        for (const property in releaseBuildConfig) {
+            const value = releaseBuildConfig[property];
             test.ok(value.name === 'Release');
         }
 
-        var debugBuildConfig = project.getBuildConfigByName('Debug');
-        for (var property in debugBuildConfig) {
-            var value = debugBuildConfig[property];
+        const debugBuildConfig = project.getBuildConfigByName('Debug');
+        for (const property in debugBuildConfig) {
+            const value = debugBuildConfig[property];
             test.ok(value.name === 'Debug');
         }
 
-        var nonExistingBuildConfig = project.getBuildConfigByName('Foo');
+        const nonExistingBuildConfig = project.getBuildConfigByName('Foo');
         test.deepEqual(nonExistingBuildConfig, {});
 
         test.done();
@@ -500,7 +500,7 @@ exports.validatePropReplaceFix = {
 
 exports.validateHasFile = {
     'should return true for has file MainViewController.m': function (test) {
-        var result = project.hasFile('MainViewController.m');
+        const result = project.hasFile('MainViewController.m');
         test.ok(result.path == 'MainViewController.m');
         test.done();
     }
@@ -510,17 +510,17 @@ exports.testWritingPBXProject = {
     'should successfully write to PBXProject TargetAttributes': function (
         test
     ) {
-        var pbxProjectObj = project.getPBXObject('PBXProject');
-        var pbxProject;
-        for (var property in pbxProjectObj) {
+        const pbxProjectObj = project.getPBXObject('PBXProject');
+        let pbxProject;
+        for (const property in pbxProjectObj) {
             if (!/comment/.test(property)) {
                 pbxProject = pbxProjectObj[property];
             }
         }
 
-        var target;
-        var projectTargets = pbxProject.targets;
-        for (var i = 0, j = pbxProject.targets.length; i < j; i++) {
+        let target;
+        const projectTargets = pbxProject.targets;
+        for (let i = 0, j = pbxProject.targets.length; i < j; i++) {
             target = pbxProject.targets[i].value;
         }
 
@@ -540,7 +540,7 @@ exports.testWritingPBXProject = {
             }
         };
 
-        var output = project.writeSync();
+        const output = project.writeSync();
 
         test.done();
     },
@@ -548,7 +548,7 @@ exports.testWritingPBXProject = {
         test
     ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
-        var output = project.writeSync();
+        const output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
 
         test.done();
@@ -557,7 +557,7 @@ exports.testWritingPBXProject = {
         test
     ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
-        var output = project.writeSync();
+        let output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
 
         project.addTargetAttribute('ProvisioningStyle', 'Automatic');
@@ -574,7 +574,7 @@ exports.testWritingPBXProject = {
         test
     ) {
         project.addTargetAttribute('ProvisioningStyle', 'Manual');
-        var output = project.writeSync();
+        let output = project.writeSync();
         test.equal(output.match(/ProvisioningStyle\s*=\s*Manual/g).length, 1);
 
         project.removeTargetAttribute('ProvisioningStyle');

--- a/test/knownRegions.js
+++ b/test/knownRegions.js
@@ -20,74 +20,108 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     project = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     project.hash = cleanHash();
     callback();
-}
+};
 
 exports.addKnownRegion = {
-  'should add new region to existing knownRegions': function (test) {
-    var knownRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'];
-    test.equal(knownRegions.indexOf('Spanish'), -1);
+    'should add new region to existing knownRegions': function (test) {
+        var knownRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'];
+        test.equal(knownRegions.indexOf('Spanish'), -1);
 
-    project.addKnownRegion('Spanish')
-    knownRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'];
-    test.notEqual(knownRegions.indexOf('Spanish'), -1);
-    test.done();
-  },
+        project.addKnownRegion('Spanish');
+        knownRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'];
+        test.notEqual(knownRegions.indexOf('Spanish'), -1);
+        test.done();
+    },
 
-  'should not add region if it already exists in knownRegions': function (test) {
-    var numberOfRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'].length;
+    'should not add region if it already exists in knownRegions': function (
+        test
+    ) {
+        var numberOfRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'].length;
 
-    project.addKnownRegion('German');
-    var newNumberOfRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'].length;
-    test.equal(numberOfRegions, newNumberOfRegions);
-    test.done();
-  },
+        project.addKnownRegion('German');
+        var newNumberOfRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'].length;
+        test.equal(numberOfRegions, newNumberOfRegions);
+        test.done();
+    },
 
-  'should create knownRegions array if it does not exist': function (test) {
-    delete project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'];
-    test.ok(!project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions']);
+    'should create knownRegions array if it does not exist': function (test) {
+        delete project.pbxProjectSection()[project.getFirstProject()['uuid']][
+            'knownRegions'
+        ];
+        test.ok(
+            !project.pbxProjectSection()[project.getFirstProject()['uuid']][
+                'knownRegions'
+            ]
+        );
 
-    project.addKnownRegion('German')
-    test.ok(project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions']);
-    test.done();
-  },
-}
+        project.addKnownRegion('German');
+        test.ok(
+            project.pbxProjectSection()[project.getFirstProject()['uuid']][
+                'knownRegions'
+            ]
+        );
+        test.done();
+    }
+};
 
 exports.removeKnownRegion = {
-  'should remove named region from knownRegions': function (test) {
-    var knownRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'];
-    test.notEqual(knownRegions.indexOf('German'), -1);
+    'should remove named region from knownRegions': function (test) {
+        var knownRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'];
+        test.notEqual(knownRegions.indexOf('German'), -1);
 
-    project.removeKnownRegion('German');
-    knownRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'];
-    test.equal(knownRegions.indexOf('German'), -1);
-    test.done();
-  },
+        project.removeKnownRegion('German');
+        knownRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'];
+        test.equal(knownRegions.indexOf('German'), -1);
+        test.done();
+    },
 
-  'should do nothing if named region does not exist in knownRegions': function (test) {
-    var numberOfRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'].length;
+    'should do nothing if named region does not exist in knownRegions': function (
+        test
+    ) {
+        var numberOfRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'].length;
 
-    project.removeKnownRegion('Korean');
-    var newNumberOfRegions = project.pbxProjectSection()[project.getFirstProject()['uuid']]['knownRegions'].length;
-    test.equal(numberOfRegions, newNumberOfRegions);
-    test.done();
-  },
-}
+        project.removeKnownRegion('Korean');
+        var newNumberOfRegions = project.pbxProjectSection()[
+            project.getFirstProject()['uuid']
+        ]['knownRegions'].length;
+        test.equal(numberOfRegions, newNumberOfRegions);
+        test.done();
+    }
+};
 
 exports.hasKnownRegion = {
-  'should return true if named region exists in knownRegions': function (test) {
-    test.ok(project.hasKnownRegion('German'));
-    test.done();
-  },
+    'should return true if named region exists in knownRegions': function (
+        test
+    ) {
+        test.ok(project.hasKnownRegion('German'));
+        test.done();
+    },
 
-  'should return false if named region does not exist in knownRegions': function (test) {
-    test.ok(!project.hasKnownRegion('Ducth'));
-    test.done();
-  },
-}
+    'should return false if named region does not exist in knownRegions': function (
+        test
+    ) {
+        test.ok(!project.hasKnownRegion('Ducth'));
+        test.done();
+    }
+};

--- a/test/knownRegions.js
+++ b/test/knownRegions.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    project = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const project = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,7 +31,7 @@ exports.setUp = function (callback) {
 
 exports.addKnownRegion = {
     'should add new region to existing knownRegions': function (test) {
-        var knownRegions = project.pbxProjectSection()[
+        let knownRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'];
         test.equal(knownRegions.indexOf('Spanish'), -1);
@@ -47,12 +47,12 @@ exports.addKnownRegion = {
     'should not add region if it already exists in knownRegions': function (
         test
     ) {
-        var numberOfRegions = project.pbxProjectSection()[
+        const numberOfRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'].length;
 
         project.addKnownRegion('German');
-        var newNumberOfRegions = project.pbxProjectSection()[
+        const newNumberOfRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'].length;
         test.equal(numberOfRegions, newNumberOfRegions);
@@ -81,7 +81,7 @@ exports.addKnownRegion = {
 
 exports.removeKnownRegion = {
     'should remove named region from knownRegions': function (test) {
-        var knownRegions = project.pbxProjectSection()[
+        let knownRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'];
         test.notEqual(knownRegions.indexOf('German'), -1);
@@ -97,12 +97,12 @@ exports.removeKnownRegion = {
     'should do nothing if named region does not exist in knownRegions': function (
         test
     ) {
-        var numberOfRegions = project.pbxProjectSection()[
+        const numberOfRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'].length;
 
         project.removeKnownRegion('Korean');
-        var newNumberOfRegions = project.pbxProjectSection()[
+        const newNumberOfRegions = project.pbxProjectSection()[
             project.getFirstProject()['uuid']
         ]['knownRegions'].length;
         test.equal(numberOfRegions, newNumberOfRegions);

--- a/test/knownRegions.js
+++ b/test/knownRegions.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     project = new pbx('.');

--- a/test/multipleTargets.js
+++ b/test/multipleTargets.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/multiple-targets'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/multiple-targets');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,43 +32,43 @@ exports.setUp = function (callback) {
 
 exports.addFilesToTarget = {
     'should add the file to a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'file.m';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'file.m';
 
-        var opt = { target: target };
-        var newFile = proj.addSourceFile(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addSourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var sources = proj.pbxSourcesBuildPhaseObj(target);
+        const sources = proj.pbxSourcesBuildPhaseObj(target);
         test.equal(sources.files[5].comment, filename + ' in Sources');
 
         test.done();
     },
     'should remove the file from the proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'file.m';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'file.m';
 
-        var opt = { target: target };
-        var newFile = proj.addSourceFile(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addSourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var sources = proj.pbxSourcesBuildPhaseObj(target);
+        let sources = proj.pbxSourcesBuildPhaseObj(target);
         test.equal(sources.files[5].comment, filename + ' in Sources');
-        var l = sources.files.length;
+        const l = sources.files.length;
 
         proj.removeSourceFile(filename, opt);
-        var sources = proj.pbxSourcesBuildPhaseObj(target);
+        sources = proj.pbxSourcesBuildPhaseObj(target);
         test.equal(sources.files.length, l - 1);
 
         test.done();
     },
     'should fail when specifying an invalid target': function (test) {
-        var target = 'XXXXX';
-        var filename = 'file.m';
+        const target = 'XXXXX';
+        const filename = 'file.m';
 
-        var opt = { target: target };
+        const opt = { target: target };
         test.throws(function () {
             proj.addSourceFile(filename, opt);
         });
@@ -76,82 +76,82 @@ exports.addFilesToTarget = {
         test.done();
     },
     'should add the library to a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'library.lib';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'library.lib';
 
-        var opt = { target: target };
-        var newFile = proj.addStaticLibrary(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addStaticLibrary(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var libraries = proj.pbxFrameworksBuildPhaseObj(target);
+        const libraries = proj.pbxFrameworksBuildPhaseObj(target);
         test.equal(libraries.files[4].comment, filename + ' in Resources');
 
         test.done();
     },
     'should remove the library to a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'library.lib';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'library.lib';
 
-        var opt = { target: target };
-        var newFile = proj.addStaticLibrary(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addStaticLibrary(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var libraries = proj.pbxFrameworksBuildPhaseObj(target);
+        let libraries = proj.pbxFrameworksBuildPhaseObj(target);
         test.equal(libraries.files[4].comment, filename + ' in Resources');
-        var l = libraries.files.length;
+        const l = libraries.files.length;
 
         proj.removeFramework(filename, opt);
-        var libraries = proj.pbxFrameworksBuildPhaseObj(target);
+        libraries = proj.pbxFrameworksBuildPhaseObj(target);
         test.equal(libraries.files.length, l - 1);
 
         test.done();
     },
     'should add the framework to a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'delta.framework';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'delta.framework';
 
-        var opt = { target: target };
-        var newFile = proj.addFramework(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addFramework(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var frameworks = proj.pbxFrameworksBuildPhaseObj(target);
+        const frameworks = proj.pbxFrameworksBuildPhaseObj(target);
         test.equal(frameworks.files[4].comment, filename + ' in Frameworks');
 
         test.done();
     },
     'should add a ressource fileto a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'delta.png';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'delta.png';
 
-        var opt = { target: target };
-        var newFile = proj.addResourceFile(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addResourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var resources = proj.pbxResourcesBuildPhaseObj(target);
+        const resources = proj.pbxResourcesBuildPhaseObj(target);
         test.equal(resources.files[26].comment, filename + ' in Resources');
 
         test.done();
     },
     'should remove a ressource file from a proper target': function (test) {
-        var target = '1D6058900D05DD3D006BFB54';
-        var filename = 'delta.png';
+        const target = '1D6058900D05DD3D006BFB54';
+        const filename = 'delta.png';
 
-        var opt = { target: target };
-        var newFile = proj.addResourceFile(filename, opt);
+        const opt = { target: target };
+        const newFile = proj.addResourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
-        var resources = proj.pbxResourcesBuildPhaseObj(target);
+        let resources = proj.pbxResourcesBuildPhaseObj(target);
         test.equal(resources.files[26].comment, filename + ' in Resources');
 
-        var l = resources.files.length;
+        const l = resources.files.length;
 
         proj.removeResourceFile(filename, opt);
-        var resources = proj.pbxResourcesBuildPhaseObj(target);
+        resources = proj.pbxResourcesBuildPhaseObj(target);
         test.equal(resources.files.length, l - 1);
 
         test.done();

--- a/test/multipleTargets.js
+++ b/test/multipleTargets.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/multiple-targets')
+var fullProject = require('./fixtures/multiple-targets'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/multipleTargets.js
+++ b/test/multipleTargets.js
@@ -21,150 +21,139 @@ var fullProject = require('./fixtures/multiple-targets'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.addFilesToTarget = {
     'should add the file to a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'file.m';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "file.m";
-
-        var opt = { target : target };
-        var newFile = proj.addSourceFile(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addSourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var sources = proj.pbxSourcesBuildPhaseObj(target);
-        test.equal(sources.files[5].comment, filename+" in Sources");
+        test.equal(sources.files[5].comment, filename + ' in Sources');
 
         test.done();
     },
     'should remove the file from the proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'file.m';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "file.m";
-
-        var opt = { target : target };
-        var newFile = proj.addSourceFile(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addSourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var sources = proj.pbxSourcesBuildPhaseObj(target);
-        test.equal(sources.files[5].comment, filename+" in Sources");
+        test.equal(sources.files[5].comment, filename + ' in Sources');
         var l = sources.files.length;
 
-        proj.removeSourceFile(filename,opt);
+        proj.removeSourceFile(filename, opt);
         var sources = proj.pbxSourcesBuildPhaseObj(target);
-         test.equal(sources.files.length,l-1);
+        test.equal(sources.files.length, l - 1);
 
         test.done();
     },
     'should fail when specifying an invalid target': function (test) {
+        var target = 'XXXXX';
+        var filename = 'file.m';
 
-        var target = "XXXXX";
-        var filename = "file.m";
-
-        var opt = { target : target };
-        test.throws(function(){
-            proj.addSourceFile(filename,opt);
+        var opt = { target: target };
+        test.throws(function () {
+            proj.addSourceFile(filename, opt);
         });
-
 
         test.done();
     },
-     'should add the library to a proper target': function (test) {
+    'should add the library to a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'library.lib';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "library.lib";
-
-        var opt = { target : target };
-        var newFile = proj.addStaticLibrary(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addStaticLibrary(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var libraries = proj.pbxFrameworksBuildPhaseObj(target);
-        test.equal(libraries.files[4].comment, filename+" in Resources");
+        test.equal(libraries.files[4].comment, filename + ' in Resources');
 
         test.done();
     },
     'should remove the library to a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'library.lib';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "library.lib";
-
-        var opt = { target : target };
-        var newFile = proj.addStaticLibrary(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addStaticLibrary(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var libraries = proj.pbxFrameworksBuildPhaseObj(target);
-        test.equal(libraries.files[4].comment, filename+" in Resources");
+        test.equal(libraries.files[4].comment, filename + ' in Resources');
         var l = libraries.files.length;
 
-        proj.removeFramework(filename,opt);
+        proj.removeFramework(filename, opt);
         var libraries = proj.pbxFrameworksBuildPhaseObj(target);
-        test.equal(libraries.files.length,l-1);
+        test.equal(libraries.files.length, l - 1);
 
         test.done();
-
     },
-     'should add the framework to a proper target': function (test) {
+    'should add the framework to a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'delta.framework';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "delta.framework";
-
-        var opt = { target : target };
-        var newFile = proj.addFramework(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addFramework(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var frameworks = proj.pbxFrameworksBuildPhaseObj(target);
-        test.equal(frameworks.files[4].comment, filename+" in Frameworks");
+        test.equal(frameworks.files[4].comment, filename + ' in Frameworks');
 
         test.done();
     },
     'should add a ressource fileto a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'delta.png';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "delta.png";
-
-        var opt = { target : target };
-        var newFile = proj.addResourceFile(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addResourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var resources = proj.pbxResourcesBuildPhaseObj(target);
-        test.equal(resources.files[26].comment, filename+" in Resources");
+        test.equal(resources.files[26].comment, filename + ' in Resources');
 
         test.done();
     },
-     'should remove a ressource file from a proper target': function (test) {
+    'should remove a ressource file from a proper target': function (test) {
+        var target = '1D6058900D05DD3D006BFB54';
+        var filename = 'delta.png';
 
-        var target = "1D6058900D05DD3D006BFB54";
-        var filename = "delta.png";
-
-        var opt = { target : target };
-        var newFile = proj.addResourceFile(filename,opt);
+        var opt = { target: target };
+        var newFile = proj.addResourceFile(filename, opt);
 
         test.equal(newFile.constructor, pbxFile);
 
         var resources = proj.pbxResourcesBuildPhaseObj(target);
-        test.equal(resources.files[26].comment, filename+" in Resources");
+        test.equal(resources.files[26].comment, filename + ' in Resources');
 
         var l = resources.files.length;
 
-        proj.removeResourceFile(filename,opt);
-         var resources = proj.pbxResourcesBuildPhaseObj(target);
-        test.equal(resources.files.length,l-1);
+        proj.removeResourceFile(filename, opt);
+        var resources = proj.pbxResourcesBuildPhaseObj(target);
+        test.equal(resources.files.length, l - 1);
 
         test.done();
-    },
-}
-
+    }
+};

--- a/test/parser/build-config.js
+++ b/test/parser/build-config.js
@@ -17,7 +17,10 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/build-config.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/build-config.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
@@ -27,7 +30,7 @@ var PEG = require('pegjs'),
 exports['should parse the build config section'] = function (test) {
     // if it gets this far it's worked
     test.done();
-}
+};
 
 exports['should read a decimal value correctly'] = function (test) {
     var xcbConfig = project.objects['XCBuildConfiguration'],
@@ -35,13 +38,14 @@ exports['should read a decimal value correctly'] = function (test) {
 
     test.strictEqual(debugSettings['IPHONEOS_DEPLOYMENT_TARGET'], '3.0');
     test.done();
-}
+};
 
 exports['should read an escaped value correctly'] = function (test) {
     var xcbConfig = project.objects['XCBuildConfiguration'],
         debugSettings = xcbConfig['C01FCF4F08A954540054247B'].buildSettings,
-        expt = '"\\"$(PHONEGAPLIB)/Classes/JSON\\" \\"$(PHONEGAPLIB)/Classes\\""';
+        expt =
+            '"\\"$(PHONEGAPLIB)/Classes/JSON\\" \\"$(PHONEGAPLIB)/Classes\\""';
 
     test.strictEqual(debugSettings['USER_HEADER_SEARCH_PATHS'], expt);
     test.done();
-}
+};

--- a/test/parser/build-config.js
+++ b/test/parser/build-config.js
@@ -15,17 +15,17 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/build-config.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    util = require('util'),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/build-config.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const util = require('util');
+const project = rawProj.project;
 
 exports['should parse the build config section'] = function (test) {
     // if it gets this far it's worked
@@ -33,17 +33,17 @@ exports['should parse the build config section'] = function (test) {
 };
 
 exports['should read a decimal value correctly'] = function (test) {
-    var xcbConfig = project.objects['XCBuildConfiguration'],
-        debugSettings = xcbConfig['1D6058950D05DD3E006BFB54'].buildSettings;
+    const xcbConfig = project.objects['XCBuildConfiguration'];
+    const debugSettings = xcbConfig['1D6058950D05DD3E006BFB54'].buildSettings;
 
     test.strictEqual(debugSettings['IPHONEOS_DEPLOYMENT_TARGET'], '3.0');
     test.done();
 };
 
 exports['should read an escaped value correctly'] = function (test) {
-    var xcbConfig = project.objects['XCBuildConfiguration'],
-        debugSettings = xcbConfig['C01FCF4F08A954540054247B'].buildSettings,
-        expt =
+    const xcbConfig = project.objects['XCBuildConfiguration'];
+    const debugSettings = xcbConfig['C01FCF4F08A954540054247B'].buildSettings;
+    const expt =
             '"\\"$(PHONEGAPLIB)/Classes/JSON\\" \\"$(PHONEGAPLIB)/Classes\\""';
 
     test.strictEqual(debugSettings['USER_HEADER_SEARCH_PATHS'], expt);

--- a/test/parser/comments.js
+++ b/test/parser/comments.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/comments.pbxproj', 'utf-8'),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar);
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync('test/parser/projects/comments.pbxproj', 'utf-8');
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
 
 // Cordova 1.8 has the Apache headers as comments in the pbxproj file
 // I DON'T KNOW WHY

--- a/test/parser/comments.js
+++ b/test/parser/comments.js
@@ -26,4 +26,4 @@ var PEG = require('pegjs'),
 exports['should ignore comments outside the main object'] = function (test) {
     parser.parse(pbx);
     test.done();
-}
+};

--- a/test/parser/dotsInNames.js
+++ b/test/parser/dotsInNames.js
@@ -17,16 +17,21 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/dots-in-names.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/dots-in-names.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
     project = rawProj.project;
 
 exports['should parse com.apple.BackgroundModes'] = function (test) {
-    var targets = project.attributes.TargetAttributes['1D6058900D05DD3D006BFB54'],
-        backgroundModes = targets.SystemCapabilities['com.apple.BackgroundModes'];
+    var targets =
+            project.attributes.TargetAttributes['1D6058900D05DD3D006BFB54'],
+        backgroundModes =
+            targets.SystemCapabilities['com.apple.BackgroundModes'];
 
-    test.deepEqual(backgroundModes, {enabled: 1});
-    test.done()
-}
+    test.deepEqual(backgroundModes, { enabled: 1 });
+    test.done();
+};

--- a/test/parser/dotsInNames.js
+++ b/test/parser/dotsInNames.js
@@ -15,21 +15,21 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/dots-in-names.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/dots-in-names.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should parse com.apple.BackgroundModes'] = function (test) {
-    var targets =
-            project.attributes.TargetAttributes['1D6058900D05DD3D006BFB54'],
-        backgroundModes =
+    const targets =
+            project.attributes.TargetAttributes['1D6058900D05DD3D006BFB54'];
+    const backgroundModes =
             targets.SystemCapabilities['com.apple.BackgroundModes'];
 
     test.deepEqual(backgroundModes, { enabled: 1 });

--- a/test/parser/file-references.js
+++ b/test/parser/file-references.js
@@ -17,7 +17,10 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/file-references.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/file-references.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
@@ -26,4 +29,4 @@ var PEG = require('pegjs'),
 exports['should have a PBXFileReference section'] = function (test) {
     test.ok(project.objects['PBXFileReference']);
     test.done();
-}
+};

--- a/test/parser/file-references.js
+++ b/test/parser/file-references.js
@@ -15,16 +15,16 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/file-references.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/file-references.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should have a PBXFileReference section'] = function (test) {
     test.ok(project.objects['PBXFileReference']);

--- a/test/parser/hash.js
+++ b/test/parser/hash.js
@@ -25,28 +25,28 @@ var PEG = require('pegjs'),
 
 exports['should have the top-line comment in place'] = function (test) {
     test.equals(rawProj.headComment, '!$*UTF8*$!');
-    test.done()
-}
+    test.done();
+};
 
 exports['should parse a numeric attribute'] = function (test) {
     test.strictEqual(project.archiveVersion, 1);
     test.strictEqual(project.objectVersion, 45);
-    test.done()
-}
+    test.done();
+};
 
 exports['should parse an empty object'] = function (test) {
     var empty = project.classes;
     test.equal(Object.keys(empty).length, 0);
-    test.done()
-}
+    test.done();
+};
 
 exports['should split out properties and comments'] = function (test) {
     test.equal(project.rootObject, '29B97313FDCFA39411CA2CEA');
     test.equal(project['rootObject_comment'], 'Project object');
     test.done();
-}
+};
 
 exports['should parse non-commented hash things'] = function (test) {
     test.equal(project.nonObject, '29B97313FDCFA39411CA2CEF');
     test.done();
-}
+};

--- a/test/parser/hash.js
+++ b/test/parser/hash.js
@@ -15,13 +15,13 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/hash.pbxproj', 'utf-8'),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync('test/parser/projects/hash.pbxproj', 'utf-8');
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should have the top-line comment in place'] = function (test) {
     test.equals(rawProj.headComment, '!$*UTF8*$!');
@@ -35,7 +35,7 @@ exports['should parse a numeric attribute'] = function (test) {
 };
 
 exports['should parse an empty object'] = function (test) {
-    var empty = project.classes;
+    const empty = project.classes;
     test.equal(Object.keys(empty).length, 0);
     test.done();
 };

--- a/test/parser/header-search.js
+++ b/test/parser/header-search.js
@@ -15,24 +15,24 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/header-search.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/header-search.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should read a decimal value correctly'] = function (test) {
-    var debug =
+    const debug =
             project.objects['XCBuildConfiguration'][
                 'C01FCF4F08A954540054247B'
-            ],
-        hsPaths = debug.buildSettings['HEADER_SEARCH_PATHS'],
-        expected = '"\\"$(TARGET_BUILD_DIR)/usr/local/lib/include\\""';
+            ];
+    const hsPaths = debug.buildSettings['HEADER_SEARCH_PATHS'];
+    const expected = '"\\"$(TARGET_BUILD_DIR)/usr/local/lib/include\\""';
 
     test.equal(hsPaths[0], expected);
     test.done();

--- a/test/parser/header-search.js
+++ b/test/parser/header-search.js
@@ -17,17 +17,23 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/header-search.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/header-search.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
     project = rawProj.project;
 
 exports['should read a decimal value correctly'] = function (test) {
-    var debug = project.objects['XCBuildConfiguration']['C01FCF4F08A954540054247B'],
+    var debug =
+            project.objects['XCBuildConfiguration'][
+                'C01FCF4F08A954540054247B'
+            ],
         hsPaths = debug.buildSettings['HEADER_SEARCH_PATHS'],
         expected = '"\\"$(TARGET_BUILD_DIR)/usr/local/lib/include\\""';
 
     test.equal(hsPaths[0], expected);
     test.done();
-}
+};

--- a/test/parser/section-entries.js
+++ b/test/parser/section-entries.js
@@ -17,7 +17,10 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/section-entries.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/section-entries.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
@@ -26,17 +29,18 @@ var PEG = require('pegjs'),
 exports['should have a PBXVariantGroup section'] = function (test) {
     test.ok(project.objects['PBXVariantGroup']);
     test.done();
-}
+};
 
 exports['should have two children for PBXVariantGroup'] = function (test) {
     test.ok(project.objects['PBXVariantGroup']['1F766FDF13BBADB100FB74C0']);
     test.ok(project.objects['PBXVariantGroup']['1F766FDC13BBADB100FB74C0']);
     test.done();
-}
+};
 
 exports['should store quote-surround values correctly'] = function (test) {
-    var localizable = project.objects['PBXVariantGroup']['1F766FDF13BBADB100FB74C0'];
+    var localizable =
+        project.objects['PBXVariantGroup']['1F766FDF13BBADB100FB74C0'];
 
     test.equal(localizable.sourceTree, '"<group>"');
     test.done();
-}
+};

--- a/test/parser/section-entries.js
+++ b/test/parser/section-entries.js
@@ -15,16 +15,16 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/section-entries.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/section-entries.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should have a PBXVariantGroup section'] = function (test) {
     test.ok(project.objects['PBXVariantGroup']);
@@ -38,7 +38,7 @@ exports['should have two children for PBXVariantGroup'] = function (test) {
 };
 
 exports['should store quote-surround values correctly'] = function (test) {
-    var localizable =
+    const localizable =
         project.objects['PBXVariantGroup']['1F766FDF13BBADB100FB74C0'];
 
     test.equal(localizable.sourceTree, '"<group>"');

--- a/test/parser/section-split.js
+++ b/test/parser/section-split.js
@@ -16,37 +16,50 @@
  */
 
 var PEG = require('pegjs'),
-	fs = require('fs'),
-	pbx = fs.readFileSync('test/parser/projects/section-split.pbxproj', 'utf-8'),
-	grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-	parser = PEG.generate(grammar),
-	rawProj = parser.parse(pbx),
-	project = rawProj.project;
+    fs = require('fs'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/section-split.pbxproj',
+        'utf-8'
+    ),
+    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
+    parser = PEG.generate(grammar),
+    rawProj = parser.parse(pbx),
+    project = rawProj.project;
 
 exports['should have a PBXTargetDependency section'] = function (test) {
-	test.ok(project.objects['PBXTargetDependency']);
-	test.done();
-}
+    test.ok(project.objects['PBXTargetDependency']);
+    test.done();
+};
 
-exports['should have the right child of PBXTargetDependency section'] = function (test) {
-	test.ok(project.objects['PBXTargetDependency']['301BF551109A68C00062928A']);
-	test.done();
-}
+exports[
+    'should have the right child of PBXTargetDependency section'
+] = function (test) {
+    test.ok(
+        project.objects['PBXTargetDependency']['301BF551109A68C00062928A']
+    );
+    test.done();
+};
 
-exports['should have the right properties on the dependency'] = function (test) {
-	var dependency = project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
+exports['should have the right properties on the dependency'] = function (
+    test
+) {
+    var dependency =
+        project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
 
-	test.equal(dependency.isa, 'PBXTargetDependency')
-	test.equal(dependency.name, 'PhoneGapLib')
-	test.equal(dependency.targetProxy, '301BF550109A68C00062928A')
-	test.equal(dependency['targetProxy_comment'], 'PBXContainerItemProxy')
+    test.equal(dependency.isa, 'PBXTargetDependency');
+    test.equal(dependency.name, 'PhoneGapLib');
+    test.equal(dependency.targetProxy, '301BF550109A68C00062928A');
+    test.equal(dependency['targetProxy_comment'], 'PBXContainerItemProxy');
 
-	test.done();
-}
+    test.done();
+};
 
 exports['should merge two PBXTargetDependency sections'] = function (test) {
-	test.ok(project.objects['PBXTargetDependency']['301BF551109A68C00062928A']);
-	test.ok(project.objects['PBXTargetDependency']['45FDD1944D304A9F96DF3AC6']);
-	test.done();
-}
-
+    test.ok(
+        project.objects['PBXTargetDependency']['301BF551109A68C00062928A']
+    );
+    test.ok(
+        project.objects['PBXTargetDependency']['45FDD1944D304A9F96DF3AC6']
+    );
+    test.done();
+};

--- a/test/parser/section-split.js
+++ b/test/parser/section-split.js
@@ -15,16 +15,16 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/section-split.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/section-split.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should have a PBXTargetDependency section'] = function (test) {
     test.ok(project.objects['PBXTargetDependency']);
@@ -43,7 +43,7 @@ exports[
 exports['should have the right properties on the dependency'] = function (
     test
 ) {
-    var dependency =
+    const dependency =
         project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
 
     test.equal(dependency.isa, 'PBXTargetDependency');

--- a/test/parser/section.js
+++ b/test/parser/section.js
@@ -15,13 +15,13 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/section.pbxproj', 'utf-8'),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync('test/parser/projects/section.pbxproj', 'utf-8');
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should have a PBXTargetDependency section'] = function (test) {
     test.ok(project.objects['PBXTargetDependency']);
@@ -40,7 +40,7 @@ exports[
 exports['should have the right properties on the dependency'] = function (
     test
 ) {
-    var dependency =
+    const dependency =
         project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
 
     test.equal(dependency.isa, 'PBXTargetDependency');

--- a/test/parser/section.js
+++ b/test/parser/section.js
@@ -26,20 +26,27 @@ var PEG = require('pegjs'),
 exports['should have a PBXTargetDependency section'] = function (test) {
     test.ok(project.objects['PBXTargetDependency']);
     test.done();
-}
+};
 
-exports['should have the right child of PBXTargetDependency section'] = function (test) {
-    test.ok(project.objects['PBXTargetDependency']['301BF551109A68C00062928A']);
+exports[
+    'should have the right child of PBXTargetDependency section'
+] = function (test) {
+    test.ok(
+        project.objects['PBXTargetDependency']['301BF551109A68C00062928A']
+    );
     test.done();
-}
+};
 
-exports['should have the right properties on the dependency'] = function (test) {
-    var dependency = project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
+exports['should have the right properties on the dependency'] = function (
+    test
+) {
+    var dependency =
+        project.objects['PBXTargetDependency']['301BF551109A68C00062928A'];
 
-    test.equal(dependency.isa, 'PBXTargetDependency')
-    test.equal(dependency.name, 'PhoneGapLib')
-    test.equal(dependency.targetProxy, '301BF550109A68C00062928A')
-    test.equal(dependency['targetProxy_comment'], 'PBXContainerItemProxy')
+    test.equal(dependency.isa, 'PBXTargetDependency');
+    test.equal(dependency.name, 'PhoneGapLib');
+    test.equal(dependency.targetProxy, '301BF550109A68C00062928A');
+    test.equal(dependency['targetProxy_comment'], 'PBXContainerItemProxy');
 
     test.done();
-}
+};

--- a/test/parser/two-sections.js
+++ b/test/parser/two-sections.js
@@ -15,16 +15,16 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync(
-        'test/parser/projects/two-sections.pbxproj',
-        'utf-8'
-    ),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync(
+    'test/parser/projects/two-sections.pbxproj',
+    'utf-8'
+);
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should parse a project with two sections'] = function (test) {
     // if it gets this far it's worked

--- a/test/parser/two-sections.js
+++ b/test/parser/two-sections.js
@@ -17,7 +17,10 @@
 
 var PEG = require('pegjs'),
     fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/two-sections.pbxproj', 'utf-8'),
+    pbx = fs.readFileSync(
+        'test/parser/projects/two-sections.pbxproj',
+        'utf-8'
+    ),
     grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
     parser = PEG.generate(grammar),
     rawProj = parser.parse(pbx),
@@ -26,10 +29,10 @@ var PEG = require('pegjs'),
 exports['should parse a project with two sections'] = function (test) {
     // if it gets this far it's worked
     test.done();
-}
+};
 
 exports['should have both sections on the project object'] = function (test) {
     test.ok(project.objects['PBXTargetDependency']);
     test.ok(project.objects['PBXSourcesBuildPhase']);
     test.done();
-}
+};

--- a/test/parser/with_array.js
+++ b/test/parser/with_array.js
@@ -15,13 +15,13 @@
  under the License.
  */
 
-var PEG = require('pegjs'),
-    fs = require('fs'),
-    pbx = fs.readFileSync('test/parser/projects/with_array.pbxproj', 'utf-8'),
-    grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8'),
-    parser = PEG.generate(grammar),
-    rawProj = parser.parse(pbx),
-    project = rawProj.project;
+const PEG = require('pegjs');
+const fs = require('fs');
+const pbx = fs.readFileSync('test/parser/projects/with_array.pbxproj', 'utf-8');
+const grammar = fs.readFileSync('lib/parser/pbxproj.pegjs', 'utf-8');
+const parser = PEG.generate(grammar);
+const rawProj = parser.parse(pbx);
+const project = rawProj.project;
 
 exports['should parse arrays with commented entries'] = function (test) {
     test.ok(project.files instanceof Array);
@@ -42,14 +42,14 @@ exports['should parse empty arrays'] = function (test) {
 };
 
 exports['should be correct ordered'] = function (test) {
-    var archs = project.ARCHS;
+    const archs = project.ARCHS;
     test.equal(archs[0], 'armv6');
     test.equal(archs[1], 'armv7');
     test.done();
 };
 
 exports['should parse values and comments correctly'] = function (test) {
-    var appDelegate = project.files[1];
+    const appDelegate = project.files[1];
     test.equal(appDelegate.value, '1D3623260D0F684500981E51');
     test.equal(appDelegate.comment, 'AppDelegate.m in Sources');
     test.done();

--- a/test/parser/with_array.js
+++ b/test/parser/with_array.js
@@ -26,31 +26,31 @@ var PEG = require('pegjs'),
 exports['should parse arrays with commented entries'] = function (test) {
     test.ok(project.files instanceof Array);
     test.equal(project.files.length, 2);
-    test.done()
-}
+    test.done();
+};
 
 exports['should parse arrays with uncommented entries'] = function (test) {
     test.ok(project.ARCHS instanceof Array);
     test.equal(project.ARCHS.length, 2);
-    test.done()
-}
+    test.done();
+};
 
 exports['should parse empty arrays'] = function (test) {
     test.ok(project.empties instanceof Array);
     test.equal(project.empties.length, 0);
     test.done();
-}
+};
 
 exports['should be correct ordered'] = function (test) {
     var archs = project.ARCHS;
     test.equal(archs[0], 'armv6');
     test.equal(archs[1], 'armv7');
     test.done();
-}
+};
 
 exports['should parse values and comments correctly'] = function (test) {
-    var appDelegate = project.files[1]
-    test.equal(appDelegate.value, '1D3623260D0F684500981E51')
-    test.equal(appDelegate.comment, 'AppDelegate.m in Sources')
-    test.done()
-}
+    var appDelegate = project.files[1];
+    test.equal(appDelegate.value, '1D3623260D0F684500981E51');
+    test.equal(appDelegate.comment, 'AppDelegate.m in Sources');
+    test.done();
+};

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -15,18 +15,18 @@
  under the License.
  */
 
-var pbxFile = require('../lib/pbxFile');
+const pbxFile = require('../lib/pbxFile');
 
 exports['lastKnownFileType'] = {
     'should detect that a .m path means sourcecode.c.objc': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('sourcecode.c.objc', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .h path means sourceFile.c.h': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.h');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.h');
 
         test.equal('sourcecode.c.h', sourceFile.lastKnownFileType);
         test.done();
@@ -35,14 +35,14 @@ exports['lastKnownFileType'] = {
     'should detect that a .bundle path means "wrapper.plug-in"': function (
         test
     ) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.bundle');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.bundle');
 
         test.equal('wrapper.plug-in', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .xib path means file.xib': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.xib');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.xib');
 
         test.equal('file.xib', sourceFile.lastKnownFileType);
         test.done();
@@ -51,7 +51,7 @@ exports['lastKnownFileType'] = {
     'should detect that a .dylib path means "compiled.mach-o.dylib"': function (
         test
     ) {
-        var sourceFile = new pbxFile('libsqlite3.dylib');
+        const sourceFile = new pbxFile('libsqlite3.dylib');
 
         test.equal('compiled.mach-o.dylib', sourceFile.lastKnownFileType);
         test.done();
@@ -60,7 +60,7 @@ exports['lastKnownFileType'] = {
     'should detect that a .tbd path means sourcecode.text-based-dylib-definition': function (
         test
     ) {
-        var sourceFile = new pbxFile('libsqlite3.tbd');
+        const sourceFile = new pbxFile('libsqlite3.tbd');
 
         test.equal(
             'sourcecode.text-based-dylib-definition',
@@ -72,14 +72,14 @@ exports['lastKnownFileType'] = {
     'should detect that a .framework path means wrapper.framework': function (
         test
     ) {
-        var sourceFile = new pbxFile('MessageUI.framework');
+        const sourceFile = new pbxFile('MessageUI.framework');
 
         test.equal('wrapper.framework', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .a path means archive.ar': function (test) {
-        var sourceFile = new pbxFile('libGoogleAnalytics.a');
+        const sourceFile = new pbxFile('libGoogleAnalytics.a');
 
         test.equal('archive.ar', sourceFile.lastKnownFileType);
         test.done();
@@ -88,14 +88,14 @@ exports['lastKnownFileType'] = {
     'should detect that a .xcdatamodel path means wrapper.xcdatamodel': function (
         test
     ) {
-        var sourceFile = new pbxFile('dataModel.xcdatamodel');
+        const sourceFile = new pbxFile('dataModel.xcdatamodel');
 
         test.equal('wrapper.xcdatamodel', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should allow lastKnownFileType to be overridden': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
             lastKnownFileType: 'somestupidtype'
         });
 
@@ -106,7 +106,7 @@ exports['lastKnownFileType'] = {
     'should set lastKnownFileType to unknown if undetectable': function (
         test
     ) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
         test.equal('unknown', sourceFile.lastKnownFileType);
         test.done();
@@ -115,45 +115,45 @@ exports['lastKnownFileType'] = {
 
 exports['group'] = {
     'should be Sources for source files': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('Sources', sourceFile.group);
         test.done();
     },
     'should be Sources for data model document files': function (test) {
-        var dataModelFile = new pbxFile('dataModel.xcdatamodeld');
+        const dataModelFile = new pbxFile('dataModel.xcdatamodeld');
 
         test.equal('Sources', dataModelFile.group);
         test.done();
     },
     'should be Frameworks for dylibs': function (test) {
-        var framework = new pbxFile('libsqlite3.dylib');
+        const framework = new pbxFile('libsqlite3.dylib');
 
         test.equal('Frameworks', framework.group);
         test.done();
     },
     'should be Frameworks for tbds': function (test) {
-        var framework = new pbxFile('libsqlite3.tbd');
+        const framework = new pbxFile('libsqlite3.tbd');
 
         test.equal('Frameworks', framework.group);
         test.done();
     },
     'should be Frameworks for frameworks': function (test) {
-        var framework = new pbxFile('MessageUI.framework');
+        const framework = new pbxFile('MessageUI.framework');
 
         test.equal('Frameworks', framework.group);
         test.done();
     },
     'should be Resources for all other files': function (test) {
-        var headerFile = new pbxFile('Plugins/ChildBrowser.h'),
-            xibFile = new pbxFile('Plugins/ChildBrowser.xib');
+        const headerFile = new pbxFile('Plugins/ChildBrowser.h');
+        const xibFile = new pbxFile('Plugins/ChildBrowser.xib');
 
         test.equal('Resources', headerFile.group);
         test.equal('Resources', xibFile.group);
         test.done();
     },
     'should be Frameworks for archives': function (test) {
-        var archive = new pbxFile('libGoogleAnalytics.a');
+        const archive = new pbxFile('libGoogleAnalytics.a');
 
         test.equal('Frameworks', archive.group);
         test.done();
@@ -162,7 +162,7 @@ exports['group'] = {
 
 exports['basename'] = {
     'should be as expected': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('ChildBrowser.m', sourceFile.basename);
         test.done();
@@ -171,35 +171,35 @@ exports['basename'] = {
 
 exports['sourceTree'] = {
     'should be SDKROOT for dylibs': function (test) {
-        var sourceFile = new pbxFile('libsqlite3.dylib');
+        const sourceFile = new pbxFile('libsqlite3.dylib');
 
         test.equal('SDKROOT', sourceFile.sourceTree);
         test.done();
     },
 
     'should be SDKROOT for tbds': function (test) {
-        var sourceFile = new pbxFile('libsqlite3.tbd');
+        const sourceFile = new pbxFile('libsqlite3.tbd');
 
         test.equal('SDKROOT', sourceFile.sourceTree);
         test.done();
     },
 
     'should be SDKROOT for frameworks': function (test) {
-        var sourceFile = new pbxFile('MessageUI.framework');
+        const sourceFile = new pbxFile('MessageUI.framework');
 
         test.equal('SDKROOT', sourceFile.sourceTree);
         test.done();
     },
 
     'should default to "<group>" otherwise': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('"<group>"', sourceFile.sourceTree);
         test.done();
     },
 
     'should be overridable either way': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
             sourceTree: 'SOMETHING'
         });
 
@@ -208,7 +208,7 @@ exports['sourceTree'] = {
     },
 
     'should be  "<group>" for archives': function (test) {
-        var archive = new pbxFile('libGoogleAnalytics.a');
+        const archive = new pbxFile('libGoogleAnalytics.a');
 
         test.equal('"<group>"', archive.sourceTree);
         test.done();
@@ -217,21 +217,21 @@ exports['sourceTree'] = {
 
 exports['path'] = {
     'should be "usr/lib" for dylibs (relative to SDKROOT)': function (test) {
-        var sourceFile = new pbxFile('libsqlite3.dylib');
+        const sourceFile = new pbxFile('libsqlite3.dylib');
 
         test.equal('usr/lib/libsqlite3.dylib', sourceFile.path);
         test.done();
     },
 
     'should be "usr/lib" for tbds (relative to SDKROOT)': function (test) {
-        var sourceFile = new pbxFile('libsqlite3.tbd');
+        const sourceFile = new pbxFile('libsqlite3.tbd');
 
         test.equal('usr/lib/libsqlite3.tbd', sourceFile.path);
         test.done();
     },
 
     'should be "System/Library/Frameworks" for frameworks': function (test) {
-        var sourceFile = new pbxFile('MessageUI.framework');
+        const sourceFile = new pbxFile('MessageUI.framework');
 
         test.equal(
             'System/Library/Frameworks/MessageUI.framework',
@@ -241,7 +241,7 @@ exports['path'] = {
     },
 
     'should default to the first argument otherwise': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
+        const sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('Plugins/ChildBrowser.m', sourceFile.path);
         test.done();
@@ -250,15 +250,15 @@ exports['path'] = {
 
 exports['settings'] = {
     'should not be defined by default': function (test) {
-        var sourceFile = new pbxFile('social.framework');
+        const sourceFile = new pbxFile('social.framework');
 
         test.equal(undefined, sourceFile.settings);
         test.done();
     },
 
     'should be undefined if weak is false or non-boolean': function (test) {
-        var sourceFile1 = new pbxFile('social.framework', { weak: false });
-        var sourceFile2 = new pbxFile('social.framework', {
+        const sourceFile1 = new pbxFile('social.framework', { weak: false });
+        const sourceFile2 = new pbxFile('social.framework', {
             weak: 'bad_value'
         });
 
@@ -270,7 +270,7 @@ exports['settings'] = {
     'should be {ATTRIBUTES:["Weak"]} if weak linking specified': function (
         test
     ) {
-        var sourceFile = new pbxFile('social.framework', { weak: true });
+        const sourceFile = new pbxFile('social.framework', { weak: true });
 
         test.deepEqual({ ATTRIBUTES: ['Weak'] }, sourceFile.settings);
         test.done();
@@ -279,7 +279,7 @@ exports['settings'] = {
     'should be {ATTRIBUTES:["CodeSignOnCopy"]} if sign specified': function (
         test
     ) {
-        var sourceFile = new pbxFile('signable.framework', {
+        const sourceFile = new pbxFile('signable.framework', {
             embed: true,
             sign: true
         });
@@ -294,7 +294,7 @@ exports['settings'] = {
     'should be {ATTRIBUTES:["Weak","CodeSignOnCopy"]} if both weak linking and sign specified': function (
         test
     ) {
-        var sourceFile = new pbxFile('signableWeak.framework', {
+        const sourceFile = new pbxFile('signableWeak.framework', {
             embed: true,
             weak: true,
             sign: true
@@ -310,7 +310,7 @@ exports['settings'] = {
     'should be {COMPILER_FLAGS:"blah"} if compiler flags specified': function (
         test
     ) {
-        var sourceFile = new pbxFile('Plugins/BarcodeScanner.m', {
+        const sourceFile = new pbxFile('Plugins/BarcodeScanner.m', {
             compilerFlags: '-std=c++11 -fno-objc-arc'
         });
 
@@ -324,7 +324,7 @@ exports['settings'] = {
     'should be .appex if {explicitFileType:\'"wrapper.app-extension"\'} specified': function (
         test
     ) {
-        var sourceFile = new pbxFile('AppExtension', {
+        const sourceFile = new pbxFile('AppExtension', {
             explicitFileType: '"wrapper.app-extension"'
         });
 

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -32,7 +32,9 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
-    'should detect that a .bundle path means "wrapper.plug-in"': function (test) {
+    'should detect that a .bundle path means "wrapper.plug-in"': function (
+        test
+    ) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.bundle');
 
         test.equal('wrapper.plug-in', sourceFile.lastKnownFileType);
@@ -46,21 +48,30 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
-    'should detect that a .dylib path means "compiled.mach-o.dylib"': function (test) {
+    'should detect that a .dylib path means "compiled.mach-o.dylib"': function (
+        test
+    ) {
         var sourceFile = new pbxFile('libsqlite3.dylib');
 
         test.equal('compiled.mach-o.dylib', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should detect that a .tbd path means sourcecode.text-based-dylib-definition': function (test) {
+    'should detect that a .tbd path means sourcecode.text-based-dylib-definition': function (
+        test
+    ) {
         var sourceFile = new pbxFile('libsqlite3.tbd');
 
-        test.equal('sourcecode.text-based-dylib-definition', sourceFile.lastKnownFileType);
+        test.equal(
+            'sourcecode.text-based-dylib-definition',
+            sourceFile.lastKnownFileType
+        );
         test.done();
     },
 
-    'should detect that a .framework path means wrapper.framework': function (test) {
+    'should detect that a .framework path means wrapper.framework': function (
+        test
+    ) {
         var sourceFile = new pbxFile('MessageUI.framework');
 
         test.equal('wrapper.framework', sourceFile.lastKnownFileType);
@@ -74,7 +85,9 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
-    'should detect that a .xcdatamodel path means wrapper.xcdatamodel': function (test) {
+    'should detect that a .xcdatamodel path means wrapper.xcdatamodel': function (
+        test
+    ) {
         var sourceFile = new pbxFile('dataModel.xcdatamodel');
 
         test.equal('wrapper.xcdatamodel', sourceFile.lastKnownFileType);
@@ -82,20 +95,23 @@ exports['lastKnownFileType'] = {
     },
 
     'should allow lastKnownFileType to be overridden': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
-                { lastKnownFileType: 'somestupidtype' });
+        var sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
+            lastKnownFileType: 'somestupidtype'
+        });
 
         test.equal('somestupidtype', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should set lastKnownFileType to unknown if undetectable': function (test) {
+    'should set lastKnownFileType to unknown if undetectable': function (
+        test
+    ) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
         test.equal('unknown', sourceFile.lastKnownFileType);
         test.done();
     }
-}
+};
 
 exports['group'] = {
     'should be Sources for source files': function (test) {
@@ -142,7 +158,7 @@ exports['group'] = {
         test.equal('Frameworks', archive.group);
         test.done();
     }
-}
+};
 
 exports['basename'] = {
     'should be as expected': function (test) {
@@ -151,7 +167,7 @@ exports['basename'] = {
         test.equal('ChildBrowser.m', sourceFile.basename);
         test.done();
     }
-}
+};
 
 exports['sourceTree'] = {
     'should be SDKROOT for dylibs': function (test) {
@@ -183,8 +199,9 @@ exports['sourceTree'] = {
     },
 
     'should be overridable either way': function (test) {
-        var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
-            { sourceTree: 'SOMETHING'});
+        var sourceFile = new pbxFile('Plugins/ChildBrowser.m', {
+            sourceTree: 'SOMETHING'
+        });
 
         test.equal('SOMETHING', sourceFile.sourceTree);
         test.done();
@@ -196,7 +213,7 @@ exports['sourceTree'] = {
         test.equal('"<group>"', archive.sourceTree);
         test.done();
     }
-}
+};
 
 exports['path'] = {
     'should be "usr/lib" for dylibs (relative to SDKROOT)': function (test) {
@@ -216,10 +233,12 @@ exports['path'] = {
     'should be "System/Library/Frameworks" for frameworks': function (test) {
         var sourceFile = new pbxFile('MessageUI.framework');
 
-        test.equal('System/Library/Frameworks/MessageUI.framework', sourceFile.path);
+        test.equal(
+            'System/Library/Frameworks/MessageUI.framework',
+            sourceFile.path
+        );
         test.done();
     },
-
 
     'should default to the first argument otherwise': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
@@ -227,64 +246,89 @@ exports['path'] = {
         test.equal('Plugins/ChildBrowser.m', sourceFile.path);
         test.done();
     }
-}
+};
 
 exports['settings'] = {
-   'should not be defined by default': function (test) {
-      var sourceFile = new pbxFile('social.framework');
+    'should not be defined by default': function (test) {
+        var sourceFile = new pbxFile('social.framework');
 
-      test.equal(undefined, sourceFile.settings);
-      test.done();
+        test.equal(undefined, sourceFile.settings);
+        test.done();
     },
 
     'should be undefined if weak is false or non-boolean': function (test) {
-        var sourceFile1 = new pbxFile('social.framework',
-            { weak: false });
-        var sourceFile2 = new pbxFile('social.framework',
-            { weak: 'bad_value' });
+        var sourceFile1 = new pbxFile('social.framework', { weak: false });
+        var sourceFile2 = new pbxFile('social.framework', {
+            weak: 'bad_value'
+        });
 
         test.equal(undefined, sourceFile1.settings);
         test.equal(undefined, sourceFile2.settings);
         test.done();
     },
 
-    'should be {ATTRIBUTES:["Weak"]} if weak linking specified': function (test) {
-        var sourceFile = new pbxFile('social.framework',
-            { weak: true });
+    'should be {ATTRIBUTES:["Weak"]} if weak linking specified': function (
+        test
+    ) {
+        var sourceFile = new pbxFile('social.framework', { weak: true });
 
-        test.deepEqual({ATTRIBUTES:["Weak"]}, sourceFile.settings);
+        test.deepEqual({ ATTRIBUTES: ['Weak'] }, sourceFile.settings);
         test.done();
     },
 
-    'should be {ATTRIBUTES:["CodeSignOnCopy"]} if sign specified': function (test) {
-        var sourceFile = new pbxFile('signable.framework',
-            { embed: true, sign: true });
+    'should be {ATTRIBUTES:["CodeSignOnCopy"]} if sign specified': function (
+        test
+    ) {
+        var sourceFile = new pbxFile('signable.framework', {
+            embed: true,
+            sign: true
+        });
 
-        test.deepEqual({ATTRIBUTES:["CodeSignOnCopy"]}, sourceFile.settings);
+        test.deepEqual(
+            { ATTRIBUTES: ['CodeSignOnCopy'] },
+            sourceFile.settings
+        );
         test.done();
     },
 
-    'should be {ATTRIBUTES:["Weak","CodeSignOnCopy"]} if both weak linking and sign specified': function (test) {
-        var sourceFile = new pbxFile('signableWeak.framework',
-            { embed: true, weak: true, sign: true });
+    'should be {ATTRIBUTES:["Weak","CodeSignOnCopy"]} if both weak linking and sign specified': function (
+        test
+    ) {
+        var sourceFile = new pbxFile('signableWeak.framework', {
+            embed: true,
+            weak: true,
+            sign: true
+        });
 
-        test.deepEqual({ATTRIBUTES:["Weak", "CodeSignOnCopy"]}, sourceFile.settings);
+        test.deepEqual(
+            { ATTRIBUTES: ['Weak', 'CodeSignOnCopy'] },
+            sourceFile.settings
+        );
         test.done();
     },
 
-    'should be {COMPILER_FLAGS:"blah"} if compiler flags specified': function (test) {
-        var sourceFile = new pbxFile('Plugins/BarcodeScanner.m',
-            { compilerFlags: "-std=c++11 -fno-objc-arc" });
+    'should be {COMPILER_FLAGS:"blah"} if compiler flags specified': function (
+        test
+    ) {
+        var sourceFile = new pbxFile('Plugins/BarcodeScanner.m', {
+            compilerFlags: '-std=c++11 -fno-objc-arc'
+        });
 
-        test.deepEqual({COMPILER_FLAGS:'"-std=c++11 -fno-objc-arc"'}, sourceFile.settings);
+        test.deepEqual(
+            { COMPILER_FLAGS: '"-std=c++11 -fno-objc-arc"' },
+            sourceFile.settings
+        );
         test.done();
     },
 
-    'should be .appex if {explicitFileType:\'"wrapper.app-extension"\'} specified': function (test) {
-        var sourceFile = new pbxFile('AppExtension',
-            { explicitFileType: '"wrapper.app-extension"'});
+    'should be .appex if {explicitFileType:\'"wrapper.app-extension"\'} specified': function (
+        test
+    ) {
+        var sourceFile = new pbxFile('AppExtension', {
+            explicitFileType: '"wrapper.app-extension"'
+        });
 
         test.equal('AppExtension.appex', sourceFile.basename);
         test.done();
     }
-}
+};

--- a/test/pbxItemByComment.js
+++ b/test/pbxItemByComment.js
@@ -20,48 +20,60 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.pbxItemByComment = {
     'should return PBXTargetDependency': function (test) {
-        var pbxItem = proj.pbxItemByComment('PBXTargetDependency', 'PBXTargetDependency');
+        var pbxItem = proj.pbxItemByComment(
+            'PBXTargetDependency',
+            'PBXTargetDependency'
+        );
 
         test.ok(pbxItem);
         test.equals(pbxItem.isa, 'PBXTargetDependency');
-        test.done()
+        test.done();
     },
     'should return PBXContainerItemProxy': function (test) {
-        var pbxItem = proj.pbxItemByComment('libPhoneGap.a', 'PBXReferenceProxy');
+        var pbxItem = proj.pbxItemByComment(
+            'libPhoneGap.a',
+            'PBXReferenceProxy'
+        );
 
         test.ok(pbxItem);
         test.equals(pbxItem.isa, 'PBXReferenceProxy');
-        test.done()
+        test.done();
     },
     'should return PBXResourcesBuildPhase': function (test) {
-        var pbxItem = proj.pbxItemByComment('Resources', 'PBXResourcesBuildPhase');
+        var pbxItem = proj.pbxItemByComment(
+            'Resources',
+            'PBXResourcesBuildPhase'
+        );
 
         test.ok(pbxItem);
         test.equals(pbxItem.isa, 'PBXResourcesBuildPhase');
-        test.done()
+        test.done();
     },
     'should return PBXShellScriptBuildPhase': function (test) {
-        var pbxItem = proj.pbxItemByComment('Touch www folder', 'PBXShellScriptBuildPhase');
+        var pbxItem = proj.pbxItemByComment(
+            'Touch www folder',
+            'PBXShellScriptBuildPhase'
+        );
 
         test.ok(pbxItem);
         test.equals(pbxItem.isa, 'PBXShellScriptBuildPhase');
-        test.done()
+        test.done();
     },
     'should return null when PBXNativeTarget not found': function (test) {
         var pbxItem = proj.pbxItemByComment('Invalid', 'PBXTargetDependency');
 
         test.equal(pbxItem, null);
-        test.done()
+        test.done();
     }
-}
+};

--- a/test/pbxItemByComment.js
+++ b/test/pbxItemByComment.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');

--- a/test/pbxItemByComment.js
+++ b/test/pbxItemByComment.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,7 +31,7 @@ exports.setUp = function (callback) {
 
 exports.pbxItemByComment = {
     'should return PBXTargetDependency': function (test) {
-        var pbxItem = proj.pbxItemByComment(
+        const pbxItem = proj.pbxItemByComment(
             'PBXTargetDependency',
             'PBXTargetDependency'
         );
@@ -41,7 +41,7 @@ exports.pbxItemByComment = {
         test.done();
     },
     'should return PBXContainerItemProxy': function (test) {
-        var pbxItem = proj.pbxItemByComment(
+        const pbxItem = proj.pbxItemByComment(
             'libPhoneGap.a',
             'PBXReferenceProxy'
         );
@@ -51,7 +51,7 @@ exports.pbxItemByComment = {
         test.done();
     },
     'should return PBXResourcesBuildPhase': function (test) {
-        var pbxItem = proj.pbxItemByComment(
+        const pbxItem = proj.pbxItemByComment(
             'Resources',
             'PBXResourcesBuildPhase'
         );
@@ -61,7 +61,7 @@ exports.pbxItemByComment = {
         test.done();
     },
     'should return PBXShellScriptBuildPhase': function (test) {
-        var pbxItem = proj.pbxItemByComment(
+        const pbxItem = proj.pbxItemByComment(
             'Touch www folder',
             'PBXShellScriptBuildPhase'
         );
@@ -71,7 +71,7 @@ exports.pbxItemByComment = {
         test.done();
     },
     'should return null when PBXNativeTarget not found': function (test) {
-        var pbxItem = proj.pbxItemByComment('Invalid', 'PBXTargetDependency');
+        const pbxItem = proj.pbxItemByComment('Invalid', 'PBXTargetDependency');
 
         test.equal(pbxItem, null);
         test.done();

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -34,27 +34,30 @@ exports['creation'] = {
         test.ok(myProj instanceof pbx);
         test.done();
     }
-}
+};
 
 exports['parseSync function'] = {
-  'should return the hash object': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj')
-          , projHash = myProj.parseSync();
+    'should return the hash object': function (test) {
+        var myProj = new pbx('test/parser/projects/hash.pbxproj'),
+            projHash = myProj.parseSync();
         test.ok(projHash);
         test.done();
-  },
-  'should contain valid data in the returned objects hash': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj')
-          , projHash = myProj.parseSync();
+    },
+    'should contain valid data in the returned objects hash': function (test) {
+        var myProj = new pbx('test/parser/projects/hash.pbxproj'),
+            projHash = myProj.parseSync();
         test.ok(projHash);
 
         test.equal(projHash.hash.project.archiveVersion, 1);
         test.equal(projHash.hash.project.objectVersion, 45);
-        test.equal(projHash.hash.project.nonObject, '29B97313FDCFA39411CA2CEF');
+        test.equal(
+            projHash.hash.project.nonObject,
+            '29B97313FDCFA39411CA2CEF'
+        );
 
         test.done();
-  },
-}
+    }
+};
 
 exports['parse function'] = {
     'should emit an "end" event': function (test) {
@@ -62,22 +65,22 @@ exports['parse function'] = {
 
         myProj.parse().on('end', function (err, projHash) {
             test.done();
-        })
+        });
     },
     'should take the end callback as a parameter': function (test) {
         var myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.done();
-        })
+        });
     },
     'should allow evented error handling': function (test) {
         var myProj = new pbx('NotARealPath.pbxproj');
 
         myProj.parse().on('error', function (err) {
-            test.equal(typeof err, "object");
+            test.equal(typeof err, 'object');
             test.done();
-        })
+        });
     },
     'should pass the hash object to the callback function': function (test) {
         var myProj = new pbx('test/parser/projects/hash.pbxproj');
@@ -85,7 +88,7 @@ exports['parse function'] = {
         myProj.parse(function (err, projHash) {
             test.ok(projHash);
             test.done();
-        })
+        });
     },
     'should handle projects with comments in the header': function (test) {
         var myProj = new pbx('test/parser/projects/comments.pbxproj');
@@ -93,7 +96,7 @@ exports['parse function'] = {
         myProj.parse(function (err, projHash) {
             test.ok(projHash);
             test.done();
-        })
+        });
     },
     'should attach the hash object to the pbx object': function (test) {
         var myProj = new pbx('test/parser/projects/hash.pbxproj');
@@ -101,182 +104,216 @@ exports['parse function'] = {
         myProj.parse(function (err, projHash) {
             test.ok(myProj.hash);
             test.done();
-        })
+        });
     },
-    'it should pass an error object back when the parsing fails': function (test) {
+    'it should pass an error object back when the parsing fails': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/fail.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.ok(err);
             test.done();
-        })
+        });
     }
-}
+};
 
 exports['allUuids function'] = {
-   'should return the right amount of uuids': function (test) {
-       var project = new pbx('.'),
-           uuids;
+    'should return the right amount of uuids': function (test) {
+        var project = new pbx('.'),
+            uuids;
 
-       project.hash = buildConfig;
-       uuids = project.allUuids();
+        project.hash = buildConfig;
+        uuids = project.allUuids();
 
-       test.equal(uuids.length, 4);
-       test.done();
-   }
-}
+        test.equal(uuids.length, 4);
+        test.done();
+    }
+};
 
 exports['generateUuid function'] = {
     'should return a 24 character string': function (test) {
-       var project = new pbx('.'),
-           newUUID;
+        var project = new pbx('.'),
+            newUUID;
 
-       project.hash = buildConfig;
-       newUUID = project.generateUuid();
+        project.hash = buildConfig;
+        newUUID = project.generateUuid();
 
-       test.equal(newUUID.length, 24);
-       test.done();
+        test.equal(newUUID.length, 24);
+        test.done();
     },
     'should be an uppercase hex string': function (test) {
-       var project = new pbx('.'),
-           uHex = /^[A-F0-9]{24}$/,
-           newUUID;
+        var project = new pbx('.'),
+            uHex = /^[A-F0-9]{24}$/,
+            newUUID;
 
-       project.hash = buildConfig;
-       newUUID = project.generateUuid();
+        project.hash = buildConfig;
+        newUUID = project.generateUuid();
 
-       test.ok(uHex.test(newUUID));
-       test.done();
+        test.ok(uHex.test(newUUID));
+        test.done();
     }
-}
+};
 
 var bcpbx = 'test/parser/projects/build-config.pbxproj';
 var original_pbx = fs.readFileSync(bcpbx, 'utf-8');
 
 exports['updateProductName function'] = {
-    setUp:function(callback) {
+    setUp: function (callback) {
         callback();
     },
-    tearDown:function(callback) {
+    tearDown: function (callback) {
         fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
         callback();
     },
-    'should change the PRODUCT_NAME field in the .pbxproj file': function (test) {
+    'should change the PRODUCT_NAME field in the .pbxproj file': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.updateProductName('furious anger');
             var newContents = myProj.writeSync();
             test.ok(newContents.match(/PRODUCT_NAME\s*=\s*"furious anger"/));
             test.done();
         });
     }
-}
+};
 
 exports['updateBuildProperty function'] = {
-    setUp:function(callback) {
+    setUp: function (callback) {
         callback();
     },
-    tearDown:function(callback) {
+    tearDown: function (callback) {
         fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
         callback();
     },
     'should change build properties in the .pbxproj file': function (test) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.updateBuildProperty('TARGETED_DEVICE_FAMILY', '"arm"');
             var newContents = myProj.writeSync();
             test.ok(newContents.match(/TARGETED_DEVICE_FAMILY\s*=\s*"arm"/));
-            myProj.updateBuildProperty('OTHER_LDFLAGS', ['T','E','S','T']);
+            myProj.updateBuildProperty('OTHER_LDFLAGS', ['T', 'E', 'S', 'T']);
             newContents = myProj.writeSync();
-            test.ok(newContents.match(/OTHER_LDFLAGS\s*=\s*\(\s*T,\s*E,\s*S,\s*T,\s*\)/))
+            test.ok(
+                newContents.match(
+                    /OTHER_LDFLAGS\s*=\s*\(\s*T,\s*E,\s*S,\s*T,\s*\)/
+                )
+            );
             test.done();
         });
     }
-}
+};
 
 exports['addBuildProperty function'] = {
-    setUp:function(callback) {
+    setUp: function (callback) {
         callback();
     },
-    tearDown:function(callback) {
+    tearDown: function (callback) {
         fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
         callback();
     },
     'should add 4 build properties in the .pbxproj file': function (test) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO');
             var newContents = myProj.writeSync();
-            test.equal(newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length, 4);
+            test.equal(
+                newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length,
+                4
+            );
             test.done();
         });
     },
-    'should add 2 build properties in the .pbxproj file for specific build': function (test) {
+    'should add 2 build properties in the .pbxproj file for specific build': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'Release');
             var newContents = myProj.writeSync();
-            test.equal(newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length, 2);
+            test.equal(
+                newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length,
+                2
+            );
             test.done();
         });
     },
-    'should not add build properties in the .pbxproj file for nonexist build': function (test) {
+    'should not add build properties in the .pbxproj file for nonexist build': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'nonexist');
             var newContents = myProj.writeSync();
             test.ok(!newContents.match(/ENABLE_BITCODE\s*=\s*NO/g));
             test.done();
         });
     }
-}
+};
 
 exports['removeBuildProperty function'] = {
-    setUp:function(callback) {
+    setUp: function (callback) {
         callback();
     },
-    tearDown:function(callback) {
+    tearDown: function (callback) {
         fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
         callback();
     },
-    'should remove all build properties in the .pbxproj file': function (test) {
+    'should remove all build properties in the .pbxproj file': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET');
             var newContents = myProj.writeSync();
             test.ok(!newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/));
             test.done();
         });
     },
-    'should remove specific build properties in the .pbxproj file': function (test) {
+    'should remove specific build properties in the .pbxproj file': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', 'Debug');
             var newContents = myProj.writeSync();
-            test.equal(newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length, 2);
+            test.equal(
+                newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length,
+                2
+            );
             test.done();
         });
     },
-    'should not remove any build properties in the .pbxproj file': function (test) {
+    'should not remove any build properties in the .pbxproj file': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
-            myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', 'notexist');
+        myProj.parse(function (err, hash) {
+            myProj.removeBuildProperty(
+                'IPHONEOS_DEPLOYMENT_TARGET',
+                'notexist'
+            );
             var newContents = myProj.writeSync();
-            test.equal(newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length, 4);
+            test.equal(
+                newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length,
+                4
+            );
             test.done();
         });
     },
-    'should fine with remove inexist build properties in the .pbxproj file': function (test) {
+    'should fine with remove inexist build properties in the .pbxproj file': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/build-config.pbxproj');
-        myProj.parse(function(err, hash) {
+        myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('ENABLE_BITCODE');
             var newContents = myProj.writeSync();
             test.ok(!newContents.match(/ENABLE_BITCODE/));
             test.done();
         });
     }
-
-}
+};
 
 exports['productName field'] = {
     'should return the product name': function (test) {
@@ -286,29 +323,40 @@ exports['productName field'] = {
         test.equal(newProj.productName, 'KitchenSinktablet');
         test.done();
     }
-}
+};
 
 exports['addPluginFile function'] = {
     'should strip the Plugin path prefix': function (test) {
         var myProj = new pbx('test/parser/projects/full.pbxproj');
 
         myProj.parse(function (err, hash) {
-            test.equal(myProj.addPluginFile('Plugins/testMac.m').path, 'testMac.m');
-            test.equal(myProj.addPluginFile('Plugins\\testWin.m').path, 'testWin.m');
+            test.equal(
+                myProj.addPluginFile('Plugins/testMac.m').path,
+                'testMac.m'
+            );
+            test.equal(
+                myProj.addPluginFile('Plugins\\testWin.m').path,
+                'testWin.m'
+            );
             test.done();
         });
     },
-    'should add files to the .pbxproj file using the / path seperator': function (test) {
+    'should add files to the .pbxproj file using the / path seperator': function (
+        test
+    ) {
         var myProj = new pbx('test/parser/projects/full.pbxproj');
 
         myProj.parse(function (err, hash) {
             var file = myProj.addPluginFile('myPlugin\\newFile.m');
 
-            test.equal(myProj.pbxFileReferenceSection()[file.fileRef].path, '"myPlugin/newFile.m"');
+            test.equal(
+                myProj.pbxFileReferenceSection()[file.fileRef].path,
+                '"myPlugin/newFile.m"'
+            );
             test.done();
         });
     }
-}
+};
 
 exports['hasFile'] = {
     'should return true if the file is in the project': function (test) {
@@ -316,15 +364,15 @@ exports['hasFile'] = {
         newProj.hash = jsonProject;
 
         //  sourceTree: '"<group>"'
-        test.ok(newProj.hasFile('AppDelegate.m'))
-        test.done()
+        test.ok(newProj.hasFile('AppDelegate.m'));
+        test.done();
     },
     'should return false if the file is not in the project': function (test) {
         var newProj = new pbx('.');
         newProj.hash = jsonProject;
 
         //  sourceTree: '"<group>"'
-        test.ok(!newProj.hasFile('NotTheAppDelegate.m'))
-        test.done()
+        test.ok(!newProj.hasFile('NotTheAppDelegate.m'));
+        test.done();
     }
-}
+};

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -15,21 +15,21 @@
  under the License.
  */
 
-var pbx = require('../lib/pbxProject'),
-    buildConfig = require('./fixtures/buildFiles'),
-    jsonProject = require('./fixtures/full-project'),
-    fs = require('fs'),
-    project;
+const pbx = require('../lib/pbxProject');
+const buildConfig = require('./fixtures/buildFiles');
+const jsonProject = require('./fixtures/full-project');
+const fs = require('fs');
+let project;
 
 exports['creation'] = {
     'should create a pbxProject with the new operator': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         test.ok(myProj instanceof pbx);
         test.done();
     },
     'should create a pbxProject without the new operator': function (test) {
-        var myProj = pbx('test/parser/projects/hash.pbxproj');
+        const myProj = pbx('test/parser/projects/hash.pbxproj');
 
         test.ok(myProj instanceof pbx);
         test.done();
@@ -38,14 +38,14 @@ exports['creation'] = {
 
 exports['parseSync function'] = {
     'should return the hash object': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj'),
-            projHash = myProj.parseSync();
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const projHash = myProj.parseSync();
         test.ok(projHash);
         test.done();
     },
     'should contain valid data in the returned objects hash': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj'),
-            projHash = myProj.parseSync();
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const projHash = myProj.parseSync();
         test.ok(projHash);
 
         test.equal(projHash.hash.project.archiveVersion, 1);
@@ -61,21 +61,21 @@ exports['parseSync function'] = {
 
 exports['parse function'] = {
     'should emit an "end" event': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         myProj.parse().on('end', function (err, projHash) {
             test.done();
         });
     },
     'should take the end callback as a parameter': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.done();
         });
     },
     'should allow evented error handling': function (test) {
-        var myProj = new pbx('NotARealPath.pbxproj');
+        const myProj = new pbx('NotARealPath.pbxproj');
 
         myProj.parse().on('error', function (err) {
             test.equal(typeof err, 'object');
@@ -83,7 +83,7 @@ exports['parse function'] = {
         });
     },
     'should pass the hash object to the callback function': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.ok(projHash);
@@ -91,7 +91,7 @@ exports['parse function'] = {
         });
     },
     'should handle projects with comments in the header': function (test) {
-        var myProj = new pbx('test/parser/projects/comments.pbxproj');
+        const myProj = new pbx('test/parser/projects/comments.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.ok(projHash);
@@ -99,7 +99,7 @@ exports['parse function'] = {
         });
     },
     'should attach the hash object to the pbx object': function (test) {
-        var myProj = new pbx('test/parser/projects/hash.pbxproj');
+        const myProj = new pbx('test/parser/projects/hash.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.ok(myProj.hash);
@@ -109,7 +109,7 @@ exports['parse function'] = {
     'it should pass an error object back when the parsing fails': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/fail.pbxproj');
+        const myProj = new pbx('test/parser/projects/fail.pbxproj');
 
         myProj.parse(function (err, projHash) {
             test.ok(err);
@@ -120,11 +120,11 @@ exports['parse function'] = {
 
 exports['allUuids function'] = {
     'should return the right amount of uuids': function (test) {
-        var project = new pbx('.'),
-            uuids;
+        const project = new pbx('.');
 
         project.hash = buildConfig;
-        uuids = project.allUuids();
+
+        const uuids = project.allUuids();
 
         test.equal(uuids.length, 4);
         test.done();
@@ -133,30 +133,30 @@ exports['allUuids function'] = {
 
 exports['generateUuid function'] = {
     'should return a 24 character string': function (test) {
-        var project = new pbx('.'),
-            newUUID;
+        const project = new pbx('.');
 
         project.hash = buildConfig;
-        newUUID = project.generateUuid();
+
+        const newUUID = project.generateUuid();
 
         test.equal(newUUID.length, 24);
         test.done();
     },
     'should be an uppercase hex string': function (test) {
-        var project = new pbx('.'),
-            uHex = /^[A-F0-9]{24}$/,
-            newUUID;
+        const project = new pbx('.');
+        const uHex = /^[A-F0-9]{24}$/;
 
         project.hash = buildConfig;
-        newUUID = project.generateUuid();
+
+        const newUUID = project.generateUuid();
 
         test.ok(uHex.test(newUUID));
         test.done();
     }
 };
 
-var bcpbx = 'test/parser/projects/build-config.pbxproj';
-var original_pbx = fs.readFileSync(bcpbx, 'utf-8');
+const bcpbx = 'test/parser/projects/build-config.pbxproj';
+const original_pbx = fs.readFileSync(bcpbx, 'utf-8');
 
 exports['updateProductName function'] = {
     setUp: function (callback) {
@@ -169,10 +169,10 @@ exports['updateProductName function'] = {
     'should change the PRODUCT_NAME field in the .pbxproj file': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.updateProductName('furious anger');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.ok(newContents.match(/PRODUCT_NAME\s*=\s*"furious anger"/));
             test.done();
         });
@@ -188,10 +188,10 @@ exports['updateBuildProperty function'] = {
         callback();
     },
     'should change build properties in the .pbxproj file': function (test) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.updateBuildProperty('TARGETED_DEVICE_FAMILY', '"arm"');
-            var newContents = myProj.writeSync();
+            let newContents = myProj.writeSync();
             test.ok(newContents.match(/TARGETED_DEVICE_FAMILY\s*=\s*"arm"/));
             myProj.updateBuildProperty('OTHER_LDFLAGS', ['T', 'E', 'S', 'T']);
             newContents = myProj.writeSync();
@@ -214,10 +214,10 @@ exports['addBuildProperty function'] = {
         callback();
     },
     'should add 4 build properties in the .pbxproj file': function (test) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.equal(
                 newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length,
                 4
@@ -228,10 +228,10 @@ exports['addBuildProperty function'] = {
     'should add 2 build properties in the .pbxproj file for specific build': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'Release');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.equal(
                 newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length,
                 2
@@ -242,10 +242,10 @@ exports['addBuildProperty function'] = {
     'should not add build properties in the .pbxproj file for nonexist build': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'nonexist');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.ok(!newContents.match(/ENABLE_BITCODE\s*=\s*NO/g));
             test.done();
         });
@@ -263,10 +263,10 @@ exports['removeBuildProperty function'] = {
     'should remove all build properties in the .pbxproj file': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.ok(!newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/));
             test.done();
         });
@@ -274,10 +274,10 @@ exports['removeBuildProperty function'] = {
     'should remove specific build properties in the .pbxproj file': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', 'Debug');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.equal(
                 newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length,
                 2
@@ -288,13 +288,13 @@ exports['removeBuildProperty function'] = {
     'should not remove any build properties in the .pbxproj file': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.removeBuildProperty(
                 'IPHONEOS_DEPLOYMENT_TARGET',
                 'notexist'
             );
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.equal(
                 newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length,
                 4
@@ -305,10 +305,10 @@ exports['removeBuildProperty function'] = {
     'should fine with remove inexist build properties in the .pbxproj file': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        const myProj = new pbx('test/parser/projects/build-config.pbxproj');
         myProj.parse(function (err, hash) {
             myProj.removeBuildProperty('ENABLE_BITCODE');
-            var newContents = myProj.writeSync();
+            const newContents = myProj.writeSync();
             test.ok(!newContents.match(/ENABLE_BITCODE/));
             test.done();
         });
@@ -317,7 +317,7 @@ exports['removeBuildProperty function'] = {
 
 exports['productName field'] = {
     'should return the product name': function (test) {
-        var newProj = new pbx('.');
+        const newProj = new pbx('.');
         newProj.hash = jsonProject;
 
         test.equal(newProj.productName, 'KitchenSinktablet');
@@ -327,7 +327,7 @@ exports['productName field'] = {
 
 exports['addPluginFile function'] = {
     'should strip the Plugin path prefix': function (test) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj');
+        const myProj = new pbx('test/parser/projects/full.pbxproj');
 
         myProj.parse(function (err, hash) {
             test.equal(
@@ -344,10 +344,10 @@ exports['addPluginFile function'] = {
     'should add files to the .pbxproj file using the / path seperator': function (
         test
     ) {
-        var myProj = new pbx('test/parser/projects/full.pbxproj');
+        const myProj = new pbx('test/parser/projects/full.pbxproj');
 
         myProj.parse(function (err, hash) {
-            var file = myProj.addPluginFile('myPlugin\\newFile.m');
+            const file = myProj.addPluginFile('myPlugin\\newFile.m');
 
             test.equal(
                 myProj.pbxFileReferenceSection()[file.fileRef].path,
@@ -360,7 +360,7 @@ exports['addPluginFile function'] = {
 
 exports['hasFile'] = {
     'should return true if the file is in the project': function (test) {
-        var newProj = new pbx('.');
+        const newProj = new pbx('.');
         newProj.hash = jsonProject;
 
         //  sourceTree: '"<group>"'
@@ -368,7 +368,7 @@ exports['hasFile'] = {
         test.done();
     },
     'should return false if the file is not in the project': function (test) {
-        var newProj = new pbx('.');
+        const newProj = new pbx('.');
         newProj.hash = jsonProject;
 
         //  sourceTree: '"<group>"'

--- a/test/pbxTargetByName.js
+++ b/test/pbxTargetByName.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');

--- a/test/pbxTargetByName.js
+++ b/test/pbxTargetByName.js
@@ -20,14 +20,14 @@ var fullProject = require('./fixtures/full-project'),
     pbx = require('../lib/pbxProject'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.pbxTargetByName = {
     'should return PBXNativeTarget': function (test) {
@@ -35,12 +35,12 @@ exports.pbxTargetByName = {
 
         test.ok(pbxTarget);
         test.equals(pbxTarget.isa, 'PBXNativeTarget');
-        test.done()
+        test.done();
     },
     'should return null when PBXNativeTarget not found': function (test) {
         var pbxTarget = proj.pbxTargetByName('Invalid');
 
         test.equal(pbxTarget, null);
-        test.done()
+        test.done();
     }
-}
+};

--- a/test/pbxTargetByName.js
+++ b/test/pbxTargetByName.js
@@ -15,10 +15,10 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,14 +31,14 @@ exports.setUp = function (callback) {
 
 exports.pbxTargetByName = {
     'should return PBXNativeTarget': function (test) {
-        var pbxTarget = proj.pbxTargetByName('KitchenSinktablet');
+        const pbxTarget = proj.pbxTargetByName('KitchenSinktablet');
 
         test.ok(pbxTarget);
         test.equals(pbxTarget.isa, 'PBXNativeTarget');
         test.done();
     },
     'should return null when PBXNativeTarget not found': function (test) {
-        var pbxTarget = proj.pbxTargetByName('Invalid');
+        const pbxTarget = proj.pbxTargetByName('Invalid');
 
         test.equal(pbxTarget, null);
         test.done();

--- a/test/pbxWriter.js
+++ b/test/pbxWriter.js
@@ -19,7 +19,7 @@ var pbx = require('../lib/pbxProject'),
     fs = require('fs'),
     myProj;
 
-function testProjectContents(filename, test, expectedFilename) {
+function testProjectContents (filename, test, expectedFilename) {
     var myProj = new pbx(filename);
 
     var content;
@@ -40,7 +40,7 @@ function testProjectContents(filename, test, expectedFilename) {
 }
 
 // for debugging failing tests
-function testContentsInDepth(filename, test) {
+function testContentsInDepth (filename, test) {
     var myProj = new pbx(filename),
         content = fs.readFileSync(filename, 'utf-8');
 
@@ -49,14 +49,17 @@ function testContentsInDepth(filename, test) {
 
     myProj.parse(function (err, projHash) {
         var written = myProj.writeSync(),
-            writtenLines = written.split('\n')
-            contentLines = content.split('\n')
+            writtenLines = written.split('\n');
+        contentLines = content.split('\n');
 
         test.equal(writtenLines.length, contentLines.length);
 
-        for (var i=0; i<writtenLines.length; i++) {
-            test.equal(writtenLines[i], contentLines[i],
-                'match failed on line ' + (i+1))
+        for (var i = 0; i < writtenLines.length; i++) {
+            test.equal(
+                writtenLines[i],
+                contentLines[i],
+                'match failed on line ' + (i + 1)
+            );
         }
 
         test.done();
@@ -71,52 +74,89 @@ exports.writeSync = {
         // Special case in that the originating project does not have a trailing comma for all of its array entries.
         // This is definitely possibly.
         // But when we write/read it out again during testing, the trailing commas are introduced by our library.
-        testProjectContents('test/parser/projects/with_array.pbxproj', test, 'test/parser/projects/expected/with_array_expected.pbxproj');
+        testProjectContents(
+            'test/parser/projects/with_array.pbxproj',
+            test,
+            'test/parser/projects/expected/with_array_expected.pbxproj'
+        );
     },
     'should write out the "section" test': function (test) {
         testProjectContents('test/parser/projects/section.pbxproj', test);
     },
     'should write out the "two-sections" test': function (test) {
-        testProjectContents('test/parser/projects/two-sections.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/two-sections.pbxproj',
+            test
+        );
     },
     'should write out the "section-entries" test': function (test) {
-        testProjectContents('test/parser/projects/section-entries.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/section-entries.pbxproj',
+            test
+        );
     },
     'should write out the "build-config" test': function (test) {
-        testProjectContents('test/parser/projects/build-config.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/build-config.pbxproj',
+            test
+        );
     },
     'should write out the "header-search" test': function (test) {
-        testProjectContents('test/parser/projects/header-search.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/header-search.pbxproj',
+            test
+        );
     },
     'should write out the "nested-object" test': function (test) {
-        testProjectContents('test/parser/projects/nested-object.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/nested-object.pbxproj',
+            test
+        );
     },
     'should write out the "build-files" test': function (test) {
         testProjectContents('test/parser/projects/build-files.pbxproj', test);
     },
     'should write out the "file-references" test': function (test) {
-        testProjectContents('test/parser/projects/file-references.pbxproj', test);
+        testProjectContents(
+            'test/parser/projects/file-references.pbxproj',
+            test
+        );
     },
-    'should not null and undefined with the "omitEmptyValues" option set to false test': function (test) {
-        var filename = 'test/parser/projects/with_omit_empty_values_disabled.pbxproj'
-        var expectedFilename = 'test/parser/projects/expected/with_omit_empty_values_disabled_expected.pbxproj'
-        var content = fs.readFileSync(expectedFilename, 'utf-8').replace(/    /g, '\t');
+    'should not null and undefined with the "omitEmptyValues" option set to false test': function (
+        test
+    ) {
+        var filename =
+            'test/parser/projects/with_omit_empty_values_disabled.pbxproj';
+        var expectedFilename =
+            'test/parser/projects/expected/with_omit_empty_values_disabled_expected.pbxproj';
+        var content = fs
+            .readFileSync(expectedFilename, 'utf-8')
+            .replace(/    /g, '\t');
         var project = new pbx(filename);
         project.parse(function (err) {
             if (err) {
                 return test.done(err);
             }
-            const group = project.addPbxGroup([], 'CustomGroup', undefined)
+            const group = project.addPbxGroup([], 'CustomGroup', undefined);
             var written = project.writeSync();
-            content = content.replace('CUSTOM_GROUP_UUID_REPLACED_BY_TEST', group.uuid)
+            content = content.replace(
+                'CUSTOM_GROUP_UUID_REPLACED_BY_TEST',
+                group.uuid
+            );
             test.equal(content, written);
             test.done();
         });
     },
-    'should drop null and undefined with the "omitEmptyValues" option set to true test': function (test) {
-        var filename = 'test/parser/projects/with_omit_empty_values_enabled.pbxproj'
-        var expectedFilename = 'test/parser/projects/expected/with_omit_empty_values_enabled_expected.pbxproj'
-        var content = fs.readFileSync(expectedFilename, 'utf-8').replace(/    /g, '\t');
+    'should drop null and undefined with the "omitEmptyValues" option set to true test': function (
+        test
+    ) {
+        var filename =
+            'test/parser/projects/with_omit_empty_values_enabled.pbxproj';
+        var expectedFilename =
+            'test/parser/projects/expected/with_omit_empty_values_enabled_expected.pbxproj';
+        var content = fs
+            .readFileSync(expectedFilename, 'utf-8')
+            .replace(/    /g, '\t');
         var project = new pbx(filename);
         project.parse(function (err) {
             if (err) {
@@ -124,9 +164,12 @@ exports.writeSync = {
             }
             var group = project.addPbxGroup([], 'CustomGroup', undefined);
             var written = project.writeSync({ omitEmptyValues: true });
-            content = content.replace('CUSTOM_GROUP_UUID_REPLACED_BY_TEST', group.uuid)
+            content = content.replace(
+                'CUSTOM_GROUP_UUID_REPLACED_BY_TEST',
+                group.uuid
+            );
             test.equal(content, written);
             test.done();
         });
     }
-}
+};

--- a/test/pbxWriter.js
+++ b/test/pbxWriter.js
@@ -15,14 +15,14 @@
  under the License.
  */
 
-var pbx = require('../lib/pbxProject'),
-    fs = require('fs'),
-    myProj;
+const pbx = require('../lib/pbxProject');
+const fs = require('fs');
+let myProj;
 
 function testProjectContents (filename, test, expectedFilename) {
-    var myProj = new pbx(filename);
+    const myProj = new pbx(filename);
 
-    var content;
+    let content;
     if (expectedFilename) {
         content = fs.readFileSync(expectedFilename, 'utf-8');
     } else {
@@ -32,7 +32,7 @@ function testProjectContents (filename, test, expectedFilename) {
     content = content.replace(/    /g, '\t');
 
     myProj.parse(function (err, projHash) {
-        var written = myProj.writeSync();
+        const written = myProj.writeSync();
 
         test.equal(content, written);
         test.done();
@@ -41,20 +41,20 @@ function testProjectContents (filename, test, expectedFilename) {
 
 // for debugging failing tests
 function testContentsInDepth (filename, test) {
-    var myProj = new pbx(filename),
-        content = fs.readFileSync(filename, 'utf-8');
+    const myProj = new pbx(filename);
+    let content = fs.readFileSync(filename, 'utf-8');
 
     // normalize tabs vs strings
     content = content.replace(/    /g, '\t');
 
     myProj.parse(function (err, projHash) {
-        var written = myProj.writeSync(),
-            writtenLines = written.split('\n');
+        const written = myProj.writeSync();
+        const writtenLines = written.split('\n');
         contentLines = content.split('\n');
 
         test.equal(writtenLines.length, contentLines.length);
 
-        for (var i = 0; i < writtenLines.length; i++) {
+        for (let i = 0; i < writtenLines.length; i++) {
             test.equal(
                 writtenLines[i],
                 contentLines[i],
@@ -125,20 +125,20 @@ exports.writeSync = {
     'should not null and undefined with the "omitEmptyValues" option set to false test': function (
         test
     ) {
-        var filename =
+        const filename =
             'test/parser/projects/with_omit_empty_values_disabled.pbxproj';
-        var expectedFilename =
+        const expectedFilename =
             'test/parser/projects/expected/with_omit_empty_values_disabled_expected.pbxproj';
-        var content = fs
+        let content = fs
             .readFileSync(expectedFilename, 'utf-8')
             .replace(/    /g, '\t');
-        var project = new pbx(filename);
+        const project = new pbx(filename);
         project.parse(function (err) {
             if (err) {
                 return test.done(err);
             }
             const group = project.addPbxGroup([], 'CustomGroup', undefined);
-            var written = project.writeSync();
+            const written = project.writeSync();
             content = content.replace(
                 'CUSTOM_GROUP_UUID_REPLACED_BY_TEST',
                 group.uuid
@@ -150,20 +150,20 @@ exports.writeSync = {
     'should drop null and undefined with the "omitEmptyValues" option set to true test': function (
         test
     ) {
-        var filename =
+        const filename =
             'test/parser/projects/with_omit_empty_values_enabled.pbxproj';
-        var expectedFilename =
+        const expectedFilename =
             'test/parser/projects/expected/with_omit_empty_values_enabled_expected.pbxproj';
-        var content = fs
+        let content = fs
             .readFileSync(expectedFilename, 'utf-8')
             .replace(/    /g, '\t');
-        var project = new pbx(filename);
+        const project = new pbx(filename);
         project.parse(function (err) {
             if (err) {
                 return test.done(err);
             }
-            var group = project.addPbxGroup([], 'CustomGroup', undefined);
-            var written = project.writeSync({ omitEmptyValues: true });
+            const group = project.addPbxGroup([], 'CustomGroup', undefined);
+            const written = project.writeSync({ omitEmptyValues: true });
             content = content.replace(
                 'CUSTOM_GROUP_UUID_REPLACED_BY_TEST',
                 group.uuid

--- a/test/removeFramework.js
+++ b/test/removeFramework.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -31,9 +31,9 @@ exports.setUp = function (callback) {
 };
 
 function nonComments (obj) {
-    var keys = Object.keys(obj),
-        newObj = {},
-        i = 0;
+    const keys = Object.keys(obj);
+    const newObj = {};
+    let i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -45,11 +45,11 @@ function nonComments (obj) {
 }
 
 function frameworkSearchPaths (proj) {
-    var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
-        allPaths = [],
-        ids = Object.keys(configs),
-        i,
-        buildSettings;
+    const configs = nonComments(proj.pbxXCBuildConfigurationSection());
+    const allPaths = [];
+    const ids = Object.keys(configs);
+    let i;
+    let buildSettings;
 
     for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
@@ -64,22 +64,22 @@ function frameworkSearchPaths (proj) {
 
 exports.removeFramework = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
 
         test.equal(newFile.constructor, pbxFile);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib');
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
 
         test.equal(deletedFile.constructor, pbxFile);
 
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
 
         test.ok(newFile.fileRef);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib');
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
 
         test.ok(deletedFile.fileRef);
 
@@ -88,7 +88,7 @@ exports.removeFramework = {
     'should remove 2 fields from the PBXFileReference section': function (
         test
     ) {
-        var newFile = proj.addFramework('libsqlite3.dylib');
+        const newFile = proj.addFramework('libsqlite3.dylib');
         (fileRefSection = proj.pbxFileReferenceSection()),
         (frsLength = Object.keys(fileRefSection).length);
 
@@ -96,7 +96,7 @@ exports.removeFramework = {
         test.ok(fileRefSection[newFile.fileRef]);
         test.ok(fileRefSection[newFile.fileRef + '_comment']);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib');
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
         frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66, frsLength);
@@ -106,15 +106,15 @@ exports.removeFramework = {
         test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const buildFileSection = proj.pbxBuildFileSection();
+        let bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
         test.ok(buildFileSection[newFile.uuid + '_comment']);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib');
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
 
         bfsLength = Object.keys(buildFileSection).length;
 
@@ -125,86 +125,86 @@ exports.removeFramework = {
         test.done();
     },
     'should remove from the Frameworks PBXGroup': function (test) {
-        var newLength = proj.pbxGroupByName('Frameworks').children.length + 1,
-            newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxGroupByName('Frameworks');
+        let newLength = proj.pbxGroupByName('Frameworks').children.length + 1;
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        const frameworks = proj.pbxGroupByName('Frameworks');
 
         test.equal(frameworks.children.length, newLength);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib'),
-            newLength = newLength - 1;
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
+        newLength = newLength - 1;
 
         test.equal(frameworks.children.length, newLength);
 
         test.done();
     },
     'should remove from the PBXFrameworksBuildPhase': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework('libsqlite3.dylib');
+        let frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
 
-        var deletedFile = proj.removeFramework('libsqlite3.dylib'),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const deletedFile = proj.removeFramework('libsqlite3.dylib');
+        frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
 
         test.done();
     },
     'should remove custom frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {
-                customFramework: true
-            }),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const newFile = proj.addFramework('/path/to/Custom.framework', {
+            customFramework: true
+        });
+        let frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
 
-        var deletedFile = proj.removeFramework('/path/to/Custom.framework', {
-                customFramework: true
-            }),
-            frameworks = proj.pbxFrameworksBuildPhaseObj();
+        const deletedFile = proj.removeFramework('/path/to/Custom.framework', {
+            customFramework: true
+        });
+        frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
 
-        var frameworkPaths = frameworkSearchPaths(proj);
+        const frameworkPaths = frameworkSearchPaths(proj);
         expectedPath = '"/path/to"';
 
         for (i = 0; i < frameworkPaths.length; i++) {
-            var current = frameworkPaths[i];
+            const current = frameworkPaths[i];
             test.ok(current.indexOf(expectedPath) == -1);
         }
 
         test.done();
     },
     'should remove embedded frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', {
-                customFramework: true,
-                embed: true,
-                sign: true
-            }),
-            frameworks = proj.pbxFrameworksBuildPhaseObj(),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addFramework('/path/to/Custom.framework', {
+            customFramework: true,
+            embed: true,
+            sign: true
+        });
+        let frameworks = proj.pbxFrameworksBuildPhaseObj();
+        let buildFileSection = proj.pbxBuildFileSection();
+        let bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(frameworks.files.length, 16);
         test.equal(62, bfsLength);
 
-        var deletedFile = proj.removeFramework('/path/to/Custom.framework', {
-                customFramework: true,
-                embed: true
-            }),
-            frameworks = proj.pbxFrameworksBuildPhaseObj(),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const deletedFile = proj.removeFramework('/path/to/Custom.framework', {
+            customFramework: true,
+            embed: true
+        });
+        frameworks = proj.pbxFrameworksBuildPhaseObj();
+        buildFileSection = proj.pbxBuildFileSection();
+        bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(frameworks.files.length, 15);
         test.equal(58, bfsLength);
 
-        var frameworkPaths = frameworkSearchPaths(proj);
+        const frameworkPaths = frameworkSearchPaths(proj);
         expectedPath = '"/path/to"';
 
         for (i = 0; i < frameworkPaths.length; i++) {
-            var current = frameworkPaths[i];
+            const current = frameworkPaths[i];
             test.ok(current.indexOf(expectedPath) == -1);
         }
 

--- a/test/removeFramework.js
+++ b/test/removeFramework.js
@@ -21,18 +21,19 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
-function nonComments(obj) {
+function nonComments (obj) {
     var keys = Object.keys(obj),
-        newObj = {}, i = 0;
+        newObj = {},
+        i = 0;
 
     for (i; i < keys.length; i++) {
         if (!/_comment$/.test(keys[i])) {
@@ -43,12 +44,14 @@ function nonComments(obj) {
     return newObj;
 }
 
-function frameworkSearchPaths(proj) {
+function frameworkSearchPaths (proj) {
     var configs = nonComments(proj.pbxXCBuildConfigurationSection()),
         allPaths = [],
-        ids = Object.keys(configs), i, buildSettings;
+        ids = Object.keys(configs),
+        i,
+        buildSettings;
 
-    for (i = 0; i< ids.length; i++) {
+    for (i = 0; i < ids.length; i++) {
         buildSettings = configs[ids[i]].buildSettings;
 
         if (buildSettings['FRAMEWORK_SEARCH_PATHS']) {
@@ -69,7 +72,7 @@ exports.removeFramework = {
 
         test.equal(deletedFile.constructor, pbxFile);
 
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addFramework('libsqlite3.dylib');
@@ -80,12 +83,14 @@ exports.removeFramework = {
 
         test.ok(deletedFile.fileRef);
 
-        test.done()
+        test.done();
     },
-    'should remove 2 fields from the PBXFileReference section': function (test) {
+    'should remove 2 fields from the PBXFileReference section': function (
+        test
+    ) {
         var newFile = proj.addFramework('libsqlite3.dylib');
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        (fileRefSection = proj.pbxFileReferenceSection()),
+        (frsLength = Object.keys(fileRefSection).length);
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
@@ -127,7 +132,7 @@ exports.removeFramework = {
         test.equal(frameworks.children.length, newLength);
 
         var deletedFile = proj.removeFramework('libsqlite3.dylib'),
-        newLength = newLength - 1;
+            newLength = newLength - 1;
 
         test.equal(frameworks.children.length, newLength);
 
@@ -147,18 +152,22 @@ exports.removeFramework = {
         test.done();
     },
     'should remove custom frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', { customFramework: true }),
+        var newFile = proj.addFramework('/path/to/Custom.framework', {
+                customFramework: true
+            }),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
 
-        var deletedFile = proj.removeFramework('/path/to/Custom.framework', { customFramework: true }),
+        var deletedFile = proj.removeFramework('/path/to/Custom.framework', {
+                customFramework: true
+            }),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
 
         var frameworkPaths = frameworkSearchPaths(proj);
-            expectedPath = '"/path/to"';
+        expectedPath = '"/path/to"';
 
         for (i = 0; i < frameworkPaths.length; i++) {
             var current = frameworkPaths[i];
@@ -168,7 +177,11 @@ exports.removeFramework = {
         test.done();
     },
     'should remove embedded frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework', { customFramework: true, embed:true, sign:true }),
+        var newFile = proj.addFramework('/path/to/Custom.framework', {
+                customFramework: true,
+                embed: true,
+                sign: true
+            }),
             frameworks = proj.pbxFrameworksBuildPhaseObj(),
             buildFileSection = proj.pbxBuildFileSection(),
             bfsLength = Object.keys(buildFileSection).length;
@@ -176,7 +189,10 @@ exports.removeFramework = {
         test.equal(frameworks.files.length, 16);
         test.equal(62, bfsLength);
 
-        var deletedFile = proj.removeFramework('/path/to/Custom.framework', { customFramework: true, embed:true }),
+        var deletedFile = proj.removeFramework('/path/to/Custom.framework', {
+                customFramework: true,
+                embed: true
+            }),
             frameworks = proj.pbxFrameworksBuildPhaseObj(),
             buildFileSection = proj.pbxBuildFileSection(),
             bfsLength = Object.keys(buildFileSection).length;
@@ -194,4 +210,4 @@ exports.removeFramework = {
 
         test.done();
     }
-}
+};

--- a/test/removeHeaderFile.js
+++ b/test/removeHeaderFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/removeHeaderFile.js
+++ b/test/removeHeaderFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,22 +32,22 @@ exports.setUp = function (callback) {
 
 exports.removeHeaderFile = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addHeaderFile('file.h');
+        const newFile = proj.addHeaderFile('file.h');
 
         test.equal(newFile.constructor, pbxFile);
 
-        var deletedFile = proj.removeHeaderFile('file.h');
+        const deletedFile = proj.removeHeaderFile('file.h');
 
         test.equal(deletedFile.constructor, pbxFile);
 
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addHeaderFile('file.h');
+        const newFile = proj.addHeaderFile('file.h');
 
         test.ok(newFile.fileRef);
 
-        var deletedFile = proj.removeHeaderFile('file.h');
+        const deletedFile = proj.removeHeaderFile('file.h');
 
         test.ok(deletedFile.fileRef);
 
@@ -56,17 +56,17 @@ exports.removeHeaderFile = {
     'should remove 2 fields from the PBXFileReference section': function (
         test
     ) {
-        var newFile = proj.addHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addHeaderFile('file.h');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let frsLength = Object.keys(fileRefSection).length;
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
         test.ok(fileRefSection[newFile.fileRef + '_comment']);
 
-        var deletedFile = proj.removeHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const deletedFile = proj.removeHeaderFile('file.h');
+        fileRefSection = proj.pbxFileReferenceSection();
+        frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66, frsLength);
         test.ok(!fileRefSection[deletedFile.fileRef]);
@@ -77,23 +77,23 @@ exports.removeHeaderFile = {
     'should remove comment from the PBXFileReference correctly': function (
         test
     ) {
-        var newFile = proj.addHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addHeaderFile('file.h');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let commentKey = newFile.fileRef + '_comment';
 
         test.equal(fileRefSection[commentKey], 'file.h');
 
-        var deletedFile = proj.removeHeaderFile('file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = deletedFile.fileRef + '_comment';
+        const deletedFile = proj.removeHeaderFile('file.h');
+        fileRefSection = proj.pbxFileReferenceSection();
+        commentKey = deletedFile.fileRef + '_comment';
         test.ok(!fileRefSection[commentKey]);
 
         test.done();
     },
     'should remove the PBXFileReference object correctly': function (test) {
-        var newFile = proj.addHeaderFile('Plugins/file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addHeaderFile('Plugins/file.h');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, 4);
@@ -102,22 +102,22 @@ exports.removeHeaderFile = {
         test.equal(fileRefEntry.path, '"file.h"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');
 
-        var deletedFile = proj.removeHeaderFile('Plugins/file.h'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[deletedFile.fileRef];
+        const deletedFile = proj.removeHeaderFile('Plugins/file.h');
+        fileRefSection = proj.pbxFileReferenceSection();
+        fileRefEntry = fileRefSection[deletedFile.fileRef];
 
         test.ok(!fileRefEntry);
 
         test.done();
     },
     'should remove from the Plugins PBXGroup group': function (test) {
-        var newFile = proj.addHeaderFile('Plugins/file.h'),
-            plugins = proj.pbxGroupByName('Plugins');
+        const newFile = proj.addHeaderFile('Plugins/file.h');
+        let plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 1);
 
-        var deletedFile = proj.removeHeaderFile('Plugins/file.h'),
-            plugins = proj.pbxGroupByName('Plugins');
+        const deletedFile = proj.removeHeaderFile('Plugins/file.h');
+        plugins = proj.pbxGroupByName('Plugins');
 
         test.equal(plugins.children.length, 0);
 

--- a/test/removeHeaderFile.js
+++ b/test/removeHeaderFile.js
@@ -21,14 +21,14 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.removeHeaderFile = {
     'should return a pbxFile': function (test) {
@@ -40,7 +40,7 @@ exports.removeHeaderFile = {
 
         test.equal(deletedFile.constructor, pbxFile);
 
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addHeaderFile('file.h');
@@ -51,9 +51,11 @@ exports.removeHeaderFile = {
 
         test.ok(deletedFile.fileRef);
 
-        test.done()
+        test.done();
     },
-    'should remove 2 fields from the PBXFileReference section': function (test) {
+    'should remove 2 fields from the PBXFileReference section': function (
+        test
+    ) {
         var newFile = proj.addHeaderFile('file.h'),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -72,7 +74,9 @@ exports.removeHeaderFile = {
 
         test.done();
     },
-    'should remove comment from the PBXFileReference correctly': function (test) {
+    'should remove comment from the PBXFileReference correctly': function (
+        test
+    ) {
         var newFile = proj.addHeaderFile('file.h'),
             fileRefSection = proj.pbxFileReferenceSection(),
             commentKey = newFile.fileRef + '_comment';
@@ -119,4 +123,4 @@ exports.removeHeaderFile = {
 
         test.done();
     }
-}
+};

--- a/test/removeResourceFile.js
+++ b/test/removeResourceFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -32,50 +32,50 @@ exports.setUp = function (callback) {
 
 exports.removeResourceFile = {
     'should return a pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.equal(newFile.constructor, pbxFile);
 
-        var deletedFile = proj.removeResourceFile('assets.bundle');
+        const deletedFile = proj.removeResourceFile('assets.bundle');
 
         test.equal(deletedFile.constructor, pbxFile);
 
         test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.uuid);
 
-        var deletedFile = proj.removeResourceFile('assets.bundle');
+        const deletedFile = proj.removeResourceFile('assets.bundle');
 
         test.ok(deletedFile.uuid);
 
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle');
+        const newFile = proj.addResourceFile('assets.bundle');
 
         test.ok(newFile.fileRef);
 
-        var deletedFile = proj.removeResourceFile('assets.bundle');
+        const deletedFile = proj.removeResourceFile('assets.bundle');
 
         test.ok(deletedFile.fileRef);
 
         test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.addResourceFile('assets.bundle');
+        let buildFileSection = proj.pbxBuildFileSection();
+        let bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(60, bfsLength);
         test.ok(buildFileSection[newFile.uuid]);
         test.ok(buildFileSection[newFile.uuid + '_comment']);
 
-        var deletedFile = proj.removeResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const deletedFile = proj.removeResourceFile('assets.bundle');
+        buildFileSection = proj.pbxBuildFileSection();
+        bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(58, bfsLength);
         test.ok(!buildFileSection[deletedFile.uuid]);
@@ -84,35 +84,35 @@ exports.removeResourceFile = {
         test.done();
     },
     'should remove the PBXBuildFile comment correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const newFile = proj.addResourceFile('assets.bundle');
+        let commentKey = newFile.uuid + '_comment';
+        let buildFileSection = proj.pbxBuildFileSection();
 
         test.equal(
             buildFileSection[commentKey],
             'assets.bundle in Resources'
         );
 
-        var deletedFile = proj.removeResourceFile('assets.bundle'),
-            commentKey = deletedFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const deletedFile = proj.removeResourceFile('assets.bundle');
+        commentKey = deletedFile.uuid + '_comment';
+        buildFileSection = proj.pbxBuildFileSection();
 
         test.ok(!buildFileSection[commentKey]);
 
         test.done();
     },
     'should remove the PBXBuildFile object correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.addResourceFile('assets.bundle');
+        let buildFileSection = proj.pbxBuildFileSection();
+        let buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry.isa, 'PBXBuildFile');
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
         test.equal(buildFileEntry.fileRef_comment, 'assets.bundle');
 
-        var deletedFile = proj.removeResourceFile('assets.bundle'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[deletedFile.uuid];
+        const deletedFile = proj.removeResourceFile('assets.bundle');
+        buildFileSection = proj.pbxBuildFileSection();
+        buildFileEntry = buildFileSection[deletedFile.uuid];
 
         test.ok(!buildFileEntry);
 
@@ -121,17 +121,17 @@ exports.removeResourceFile = {
     'should remove 2 fields from the PBXFileReference section': function (
         test
     ) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.addResourceFile('assets.bundle');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let frsLength = Object.keys(fileRefSection).length;
 
         test.equal(68, frsLength);
         test.ok(fileRefSection[newFile.fileRef]);
         test.ok(fileRefSection[newFile.fileRef + '_comment']);
 
-        var deletedFile = proj.removeResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const deletedFile = proj.removeResourceFile('assets.bundle');
+        fileRefSection = proj.pbxFileReferenceSection();
+        frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66, frsLength);
         test.ok(!fileRefSection[deletedFile.fileRef]);
@@ -140,15 +140,15 @@ exports.removeResourceFile = {
         test.done();
     },
     'should populate the PBXFileReference comment correctly': function (test) {
-        var newFile = proj.addResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.addResourceFile('assets.bundle');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let commentKey = newFile.fileRef + '_comment';
 
         test.equal(fileRefSection[commentKey], 'assets.bundle');
 
-        var deletedFile = proj.removeResourceFile('assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = deletedFile.fileRef + '_comment';
+        const deletedFile = proj.removeResourceFile('assets.bundle');
+        fileRefSection = proj.pbxFileReferenceSection();
+        commentKey = deletedFile.fileRef + '_comment';
 
         test.ok(!fileRefSection[commentKey]);
         test.done();
@@ -156,9 +156,9 @@ exports.removeResourceFile = {
     'should remove the PBXFileReference object correctly': function (test) {
         delete proj.pbxGroupByName('Resources').path;
 
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        let fileRefSection = proj.pbxFileReferenceSection();
+        let fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
@@ -167,34 +167,34 @@ exports.removeResourceFile = {
         test.equal(fileRefEntry.path, '"Resources/assets.bundle"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');
 
-        var deletedFile = proj.removeResourceFile('Resources/assets.bundle'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[deletedFile.fileRef];
+        const deletedFile = proj.removeResourceFile('Resources/assets.bundle');
+        fileRefSection = proj.pbxFileReferenceSection();
+        fileRefEntry = fileRefSection[deletedFile.fileRef];
 
         test.ok(!fileRefEntry);
 
         test.done();
     },
     'should remove from the Resources PBXGroup group': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            resources = proj.pbxGroupByName('Resources');
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        let resources = proj.pbxGroupByName('Resources');
 
         test.equal(resources.children.length, 10);
 
-        var deletedFile = proj.removeResourceFile('Resources/assets.bundle'),
-            resources = proj.pbxGroupByName('Resources');
+        const deletedFile = proj.removeResourceFile('Resources/assets.bundle');
+        resources = proj.pbxGroupByName('Resources');
 
         test.equal(resources.children.length, 9);
         test.done();
     },
     'should remove from the PBXSourcesBuildPhase': function (test) {
-        var newFile = proj.addResourceFile('Resources/assets.bundle'),
-            sources = proj.pbxResourcesBuildPhaseObj();
+        const newFile = proj.addResourceFile('Resources/assets.bundle');
+        let sources = proj.pbxResourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 13);
 
-        var deletedFile = proj.removeResourceFile('Resources/assets.bundle'),
-            sources = proj.pbxResourcesBuildPhaseObj();
+        const deletedFile = proj.removeResourceFile('Resources/assets.bundle');
+        sources = proj.pbxResourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 12);
         test.done();

--- a/test/removeResourceFile.js
+++ b/test/removeResourceFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/removeResourceFile.js
+++ b/test/removeResourceFile.js
@@ -21,14 +21,14 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.removeResourceFile = {
     'should return a pbxFile': function (test) {
@@ -40,7 +40,7 @@ exports.removeResourceFile = {
 
         test.equal(deletedFile.constructor, pbxFile);
 
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         var newFile = proj.addResourceFile('assets.bundle');
@@ -51,7 +51,7 @@ exports.removeResourceFile = {
 
         test.ok(deletedFile.uuid);
 
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addResourceFile('assets.bundle');
@@ -62,7 +62,7 @@ exports.removeResourceFile = {
 
         test.ok(deletedFile.fileRef);
 
-        test.done()
+        test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
         var newFile = proj.addResourceFile('assets.bundle'),
@@ -88,7 +88,10 @@ exports.removeResourceFile = {
             commentKey = newFile.uuid + '_comment',
             buildFileSection = proj.pbxBuildFileSection();
 
-        test.equal(buildFileSection[commentKey], 'assets.bundle in Resources');
+        test.equal(
+            buildFileSection[commentKey],
+            'assets.bundle in Resources'
+        );
 
         var deletedFile = proj.removeResourceFile('assets.bundle'),
             commentKey = deletedFile.uuid + '_comment',
@@ -115,7 +118,9 @@ exports.removeResourceFile = {
 
         test.done();
     },
-    'should remove 2 fields from the PBXFileReference section': function (test) {
+    'should remove 2 fields from the PBXFileReference section': function (
+        test
+    ) {
         var newFile = proj.addResourceFile('assets.bundle'),
             fileRefSection = proj.pbxFileReferenceSection(),
             frsLength = Object.keys(fileRefSection).length;
@@ -198,4 +203,4 @@ exports.removeResourceFile = {
         delete proj.pbxGroupByName('Resources').path;
         callback();
     }
-}
+};

--- a/test/removeSourceFile.js
+++ b/test/removeSourceFile.js
@@ -15,11 +15,11 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project'),
-    fullProjectStr = JSON.stringify(fullProject),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.');
+const fullProject = require('./fixtures/full-project');
+const fullProjectStr = JSON.stringify(fullProject);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
 
 function cleanHash () {
     return JSON.parse(fullProjectStr);
@@ -33,30 +33,30 @@ exports.setUp = function (callback) {
 exports.removeSourceFile = {
     'should return a pbxFile': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m');
+        const newFile = proj.removeSourceFile('file.m');
 
         test.equal(newFile.constructor, pbxFile);
         test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m');
+        const newFile = proj.removeSourceFile('file.m');
 
         test.ok(newFile.uuid);
         test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m');
+        const newFile = proj.removeSourceFile('file.m');
 
         test.ok(newFile.fileRef);
         test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            bfsLength = Object.keys(buildFileSection).length;
+        const newFile = proj.removeSourceFile('file.m');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(58, bfsLength);
         test.ok(!buildFileSection[newFile.uuid]);
@@ -66,17 +66,17 @@ exports.removeSourceFile = {
     },
     'should remove comment from the PBXBuildFile correctly': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m'),
-            commentKey = newFile.uuid + '_comment',
-            buildFileSection = proj.pbxBuildFileSection();
+        const newFile = proj.removeSourceFile('file.m');
+        const commentKey = newFile.uuid + '_comment';
+        const buildFileSection = proj.pbxBuildFileSection();
         test.notEqual(!buildFileSection[commentKey], 'file.m in Sources');
         test.done();
     },
     'should remove the PBXBuildFile object correctly': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m'),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
+        const newFile = proj.removeSourceFile('file.m');
+        const buildFileSection = proj.pbxBuildFileSection();
+        const buildFileEntry = buildFileSection[newFile.uuid];
 
         test.equal(buildFileEntry, undefined);
 
@@ -86,9 +86,9 @@ exports.removeSourceFile = {
         test
     ) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            frsLength = Object.keys(fileRefSection).length;
+        const newFile = proj.removeSourceFile('file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const frsLength = Object.keys(fileRefSection).length;
 
         test.equal(66, frsLength);
         test.ok(!fileRefSection[newFile.fileRef]);
@@ -98,50 +98,50 @@ exports.removeSourceFile = {
     },
     'should remove the PBXFileReference comment correctly': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            commentKey = newFile.fileRef + '_comment';
+        const newFile = proj.removeSourceFile('file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const commentKey = newFile.fileRef + '_comment';
 
         test.ok(!fileRefSection[commentKey]);
         test.done();
     },
     'should remove the PBXFileReference object correctly': function (test) {
         proj.addSourceFile('file.m');
-        var newFile = proj.removeSourceFile('Plugins/file.m'),
-            fileRefSection = proj.pbxFileReferenceSection(),
-            fileRefEntry = fileRefSection[newFile.fileRef];
+        const newFile = proj.removeSourceFile('Plugins/file.m');
+        const fileRefSection = proj.pbxFileReferenceSection();
+        const fileRefEntry = fileRefSection[newFile.fileRef];
         test.ok(!fileRefEntry);
         test.done();
     },
     'should remove from the Plugins PBXGroup group': function (test) {
         proj.addSourceFile('Plugins/file.m');
-        var newFile = proj.removeSourceFile('Plugins/file.m'),
-            plugins = proj.pbxGroupByName('Plugins');
+        const newFile = proj.removeSourceFile('Plugins/file.m');
+        const plugins = proj.pbxGroupByName('Plugins');
         test.equal(plugins.children.length, 0);
         test.done();
     },
     'should have the right values for the PBXGroup entry': function (test) {
         proj.addSourceFile('Plugins/file.m');
-        var newFile = proj.removeSourceFile('Plugins/file.m'),
-            plugins = proj.pbxGroupByName('Plugins'),
-            pluginObj = plugins.children[0];
+        const newFile = proj.removeSourceFile('Plugins/file.m');
+        const plugins = proj.pbxGroupByName('Plugins');
+        const pluginObj = plugins.children[0];
 
         test.ok(!pluginObj);
         test.done();
     },
     'should remove from the PBXSourcesBuildPhase': function (test) {
         proj.addSourceFile('Plugins/file.m');
-        var newFile = proj.removeSourceFile('Plugins/file.m'),
-            sources = proj.pbxSourcesBuildPhaseObj();
+        const newFile = proj.removeSourceFile('Plugins/file.m');
+        const sources = proj.pbxSourcesBuildPhaseObj();
 
         test.equal(sources.files.length, 2);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
         proj.addSourceFile('Plugins/file.m');
-        var newFile = proj.removeSourceFile('Plugins/file.m'),
-            sources = proj.pbxSourcesBuildPhaseObj(),
-            sourceObj = sources.files[2];
+        const newFile = proj.removeSourceFile('Plugins/file.m');
+        const sources = proj.pbxSourcesBuildPhaseObj();
+        const sourceObj = sources.files[2];
 
         test.ok(!sourceObj);
         test.done();
@@ -149,15 +149,15 @@ exports.removeSourceFile = {
     'should remove file from PBXFileReference after modified by Xcode': function (
         test
     ) {
-        var fileRef = proj.addSourceFile('Plugins/file.m').fileRef;
+        const fileRef = proj.addSourceFile('Plugins/file.m').fileRef;
 
         // Simulate Xcode's behaviour of stripping quotes around path and name
         // properties.
-        var entry = proj.pbxFileReferenceSection()[fileRef];
+        const entry = proj.pbxFileReferenceSection()[fileRef];
         entry.name = entry.name.replace(/^"(.*)"$/, '$1');
         entry.path = entry.path.replace(/^"(.*)"$/, '$1');
 
-        var newFile = proj.removeSourceFile('Plugins/file.m');
+        const newFile = proj.removeSourceFile('Plugins/file.m');
 
         test.ok(newFile.uuid);
         test.ok(!proj.pbxFileReferenceSection()[fileRef]);

--- a/test/removeSourceFile.js
+++ b/test/removeSourceFile.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),

--- a/test/removeSourceFile.js
+++ b/test/removeSourceFile.js
@@ -21,14 +21,14 @@ var fullProject = require('./fixtures/full-project'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(fullProjectStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 exports.removeSourceFile = {
     'should return a pbxFile': function (test) {
@@ -36,21 +36,21 @@ exports.removeSourceFile = {
         var newFile = proj.removeSourceFile('file.m');
 
         test.equal(newFile.constructor, pbxFile);
-        test.done()
+        test.done();
     },
     'should set a uuid on the pbxFile': function (test) {
         proj.addSourceFile('file.m');
         var newFile = proj.removeSourceFile('file.m');
 
         test.ok(newFile.uuid);
-        test.done()
+        test.done();
     },
     'should set a fileRef on the pbxFile': function (test) {
         proj.addSourceFile('file.m');
         var newFile = proj.removeSourceFile('file.m');
 
         test.ok(newFile.fileRef);
-        test.done()
+        test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
         proj.addSourceFile('file.m');
@@ -82,7 +82,9 @@ exports.removeSourceFile = {
 
         test.done();
     },
-    'should remove 2 fields from the PBXFileReference section': function (test) {
+    'should remove 2 fields from the PBXFileReference section': function (
+        test
+    ) {
         proj.addSourceFile('file.m');
         var newFile = proj.removeSourceFile('file.m'),
             fileRefSection = proj.pbxFileReferenceSection(),
@@ -144,14 +146,16 @@ exports.removeSourceFile = {
         test.ok(!sourceObj);
         test.done();
     },
-    'should remove file from PBXFileReference after modified by Xcode': function(test) {
+    'should remove file from PBXFileReference after modified by Xcode': function (
+        test
+    ) {
         var fileRef = proj.addSourceFile('Plugins/file.m').fileRef;
 
         // Simulate Xcode's behaviour of stripping quotes around path and name
         // properties.
         var entry = proj.pbxFileReferenceSection()[fileRef];
-        entry.name = entry.name.replace(/^"(.*)"$/, "$1");
-        entry.path = entry.path.replace(/^"(.*)"$/, "$1");
+        entry.name = entry.name.replace(/^"(.*)"$/, '$1');
+        entry.path = entry.path.replace(/^"(.*)"$/, '$1');
 
         var newFile = proj.removeSourceFile('Plugins/file.m');
 
@@ -159,5 +163,4 @@ exports.removeSourceFile = {
         test.ok(!proj.pbxFileReferenceSection()[fileRef]);
         test.done();
     }
-}
-
+};

--- a/test/variantGroup.js
+++ b/test/variantGroup.js
@@ -19,7 +19,7 @@ var pbx = require('../lib/pbxProject'),
     project,
     projectHash;
 
-var findChildInGroup = function(obj, target) {
+var findChildInGroup = function (obj, target) {
     var found = false;
 
     for (var i = 0, j = obj.children.length; i < j; i++) {
@@ -30,9 +30,9 @@ var findChildInGroup = function(obj, target) {
     }
 
     return found;
-}
+};
 
-var findFileByUUID = function(obj, target) {
+var findFileByUUID = function (obj, target) {
     var found = false;
 
     for (var k = 0, l = obj.files.length; k < l; k++) {
@@ -43,9 +43,9 @@ var findFileByUUID = function(obj, target) {
     }
 
     return found;
-}
+};
 
-var findByFileRef = function(obj, target) {
+var findByFileRef = function (obj, target) {
     var found = false;
 
     for (var property in obj) {
@@ -57,9 +57,9 @@ var findByFileRef = function(obj, target) {
         }
     }
     return found;
-}
+};
 
-var findByName = function(obj, target) {
+var findByName = function (obj, target) {
     var found = false;
     for (var property in obj) {
         if (!/comment/.test(property)) {
@@ -70,25 +70,27 @@ var findByName = function(obj, target) {
         }
     }
     return found;
-}
+};
 
-exports.setUp = function(callback) {
+exports.setUp = function (callback) {
     project = new pbx('test/parser/projects/variantgroup.pbxproj');
     projectHash = project.parseSync();
     callback();
-}
+};
 
 exports.getVariantGroupByKey = {
-    'should return PBXVariantGroup for Localizable.strings': function(test) {
-        var groupKey = project.findPBXVariantGroupKey({name: 'Localizable.strings'});
+    'should return PBXVariantGroup for Localizable.strings': function (test) {
+        var groupKey = project.findPBXVariantGroupKey({
+            name: 'Localizable.strings'
+        });
         var group = project.getPBXVariantGroupByKey(groupKey);
         test.ok(group.name === 'Localizable.strings');
         test.done();
     }
-}
+};
 
 exports.createVariantGroup = {
-    'should create a new Test Variant Group': function(test) {
+    'should create a new Test Variant Group': function (test) {
         delete project.getPBXObject('PBXVariantGroup');
 
         var found = false;
@@ -97,7 +99,7 @@ exports.createVariantGroup = {
         var found = findByName(groups, 'Test');
         test.ok(found === false);
 
-        var group = project.findPBXVariantGroupKey({name:'Test'});
+        var group = project.findPBXVariantGroupKey({ name: 'Test' });
         test.ok(group === undefined);
 
         project.pbxCreateVariantGroup('Test');
@@ -106,33 +108,42 @@ exports.createVariantGroup = {
         found = findByName(groups, 'Test');
         test.ok(found === true);
 
-        group = project.findPBXVariantGroupKey({name:'Test'});
+        group = project.findPBXVariantGroupKey({ name: 'Test' });
         test.ok(typeof group === 'string');
         test.done();
     }
-}
+};
 
 exports.findVariantGroupKey = {
-    'should return a valid group key':function(test) {
-        var keyByName = project.findPBXVariantGroupKey({ name: 'Localizable.strings'});
-        var nonExistingKey = project.findPBXVariantGroupKey({ name: 'Foo'});
+    'should return a valid group key': function (test) {
+        var keyByName = project.findPBXVariantGroupKey({
+            name: 'Localizable.strings'
+        });
+        var nonExistingKey = project.findPBXVariantGroupKey({ name: 'Foo' });
 
         test.ok(keyByName === '07E3BDBC1DF1DEA500E49912');
         test.ok(nonExistingKey === undefined);
 
         test.done();
     }
-}
+};
 
 exports.createLocalisationVariantGroup = {
-    'should create a new localisation variationgroup then add group to Resources group': function(test) {
+    'should create a new localisation variationgroup then add group to Resources group': function (
+        test
+    ) {
         delete project.getPBXObject('PBXVariantGroup');
 
-        var localizationVariantGp = project.addLocalizationVariantGroup('InfoPlist.strings');
+        var localizationVariantGp = project.addLocalizationVariantGroup(
+            'InfoPlist.strings'
+        );
 
-        var resourceGroupKey =  project.findPBXGroupKey({name: 'Resources'});
+        var resourceGroupKey = project.findPBXGroupKey({ name: 'Resources' });
         var resourceGroup = project.getPBXGroupByKey(resourceGroupKey);
-        var foundInResourcesGroup = findChildInGroup(resourceGroup, localizationVariantGp.fileRef );
+        var foundInResourcesGroup = findChildInGroup(
+            resourceGroup,
+            localizationVariantGp.fileRef
+        );
         test.ok(foundInResourcesGroup);
 
         var foundInResourcesBuildPhase = false;
@@ -147,16 +158,24 @@ exports.createLocalisationVariantGroup = {
 
         test.done();
     }
-}
+};
 
 exports.addResourceFileToLocalisationGroup = {
-    'should add resource file to the TestVariantGroup group' : function(test) {
-
-        var infoPlistVarGp = project.addLocalizationVariantGroup('InfoPlist.strings');
+    'should add resource file to the TestVariantGroup group': function (test) {
+        var infoPlistVarGp = project.addLocalizationVariantGroup(
+            'InfoPlist.strings'
+        );
         var testKey = infoPlistVarGp.fileRef;
-        var file = project.addResourceFile('Resources/en.lproj/Localization.strings', {variantGroup: true}, testKey);
+        var file = project.addResourceFile(
+            'Resources/en.lproj/Localization.strings',
+            { variantGroup: true },
+            testKey
+        );
 
-        var foundInLocalisationVariantGroup = findChildInGroup(project.getPBXVariantGroupByKey(testKey), file.fileRef );
+        var foundInLocalisationVariantGroup = findChildInGroup(
+            project.getPBXVariantGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInLocalisationVariantGroup);
 
         var foundInResourcesBuildPhase = false;
@@ -174,21 +193,39 @@ exports.addResourceFileToLocalisationGroup = {
 
         test.done();
     }
-}
+};
 
 exports.removeResourceFileFromGroup = {
-    'should add resource file then remove resource file from Localizable.strings group' : function(test) {
-        var testKey = project.findPBXVariantGroupKey({name:'Localizable.strings'});
-        var file = project.addResourceFile('Resources/zh.lproj/Localization.strings', {}, testKey);
+    'should add resource file then remove resource file from Localizable.strings group': function (
+        test
+    ) {
+        var testKey = project.findPBXVariantGroupKey({
+            name: 'Localizable.strings'
+        });
+        var file = project.addResourceFile(
+            'Resources/zh.lproj/Localization.strings',
+            {},
+            testKey
+        );
 
-        var foundInGroup = findChildInGroup(project.getPBXVariantGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXVariantGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(foundInGroup);
 
-        project.removeResourceFile('Resources/zh.lproj/Localization.strings', {}, testKey);
+        project.removeResourceFile(
+            'Resources/zh.lproj/Localization.strings',
+            {},
+            testKey
+        );
 
-        var foundInGroup = findChildInGroup(project.getPBXVariantGroupByKey(testKey),file.fileRef );
+        var foundInGroup = findChildInGroup(
+            project.getPBXVariantGroupByKey(testKey),
+            file.fileRef
+        );
         test.ok(!foundInGroup);
 
         test.done();
     }
-}
+};

--- a/test/variantGroup.js
+++ b/test/variantGroup.js
@@ -15,14 +15,14 @@
  under the License.
  */
 
-var pbx = require('../lib/pbxProject'),
-    project,
-    projectHash;
+const pbx = require('../lib/pbxProject');
+let project;
+let projectHash;
 
-var findChildInGroup = function (obj, target) {
-    var found = false;
+const findChildInGroup = function (obj, target) {
+    let found = false;
 
-    for (var i = 0, j = obj.children.length; i < j; i++) {
+    for (let i = 0, j = obj.children.length; i < j; i++) {
         if (obj.children[i].value === target) {
             found = true;
             break;
@@ -32,10 +32,10 @@ var findChildInGroup = function (obj, target) {
     return found;
 };
 
-var findFileByUUID = function (obj, target) {
-    var found = false;
+const findFileByUUID = function (obj, target) {
+    let found = false;
 
-    for (var k = 0, l = obj.files.length; k < l; k++) {
+    for (let k = 0, l = obj.files.length; k < l; k++) {
         if (obj.files[k].value === target) {
             found = true;
             break;
@@ -45,10 +45,10 @@ var findFileByUUID = function (obj, target) {
     return found;
 };
 
-var findByFileRef = function (obj, target) {
-    var found = false;
+const findByFileRef = function (obj, target) {
+    let found = false;
 
-    for (var property in obj) {
+    for (const property in obj) {
         if (!/comment/.test(property)) {
             if (obj[property].fileRef === target) {
                 found = true;
@@ -59,11 +59,11 @@ var findByFileRef = function (obj, target) {
     return found;
 };
 
-var findByName = function (obj, target) {
-    var found = false;
-    for (var property in obj) {
+const findByName = function (obj, target) {
+    let found = false;
+    for (const property in obj) {
         if (!/comment/.test(property)) {
-            var value = obj[property];
+            const value = obj[property];
             if (value.name === target) {
                 found = true;
             }
@@ -80,10 +80,10 @@ exports.setUp = function (callback) {
 
 exports.getVariantGroupByKey = {
     'should return PBXVariantGroup for Localizable.strings': function (test) {
-        var groupKey = project.findPBXVariantGroupKey({
+        const groupKey = project.findPBXVariantGroupKey({
             name: 'Localizable.strings'
         });
-        var group = project.getPBXVariantGroupByKey(groupKey);
+        const group = project.getPBXVariantGroupByKey(groupKey);
         test.ok(group.name === 'Localizable.strings');
         test.done();
     }
@@ -93,13 +93,13 @@ exports.createVariantGroup = {
     'should create a new Test Variant Group': function (test) {
         delete project.getPBXObject('PBXVariantGroup');
 
-        var found = false;
-        var groups = project.getPBXObject('PBXVariantGroup');
+        let found = false;
+        let groups = project.getPBXObject('PBXVariantGroup');
 
-        var found = findByName(groups, 'Test');
+        found = findByName(groups, 'Test');
         test.ok(found === false);
 
-        var group = project.findPBXVariantGroupKey({ name: 'Test' });
+        let group = project.findPBXVariantGroupKey({ name: 'Test' });
         test.ok(group === undefined);
 
         project.pbxCreateVariantGroup('Test');
@@ -116,10 +116,10 @@ exports.createVariantGroup = {
 
 exports.findVariantGroupKey = {
     'should return a valid group key': function (test) {
-        var keyByName = project.findPBXVariantGroupKey({
+        const keyByName = project.findPBXVariantGroupKey({
             name: 'Localizable.strings'
         });
-        var nonExistingKey = project.findPBXVariantGroupKey({ name: 'Foo' });
+        const nonExistingKey = project.findPBXVariantGroupKey({ name: 'Foo' });
 
         test.ok(keyByName === '07E3BDBC1DF1DEA500E49912');
         test.ok(nonExistingKey === undefined);
@@ -134,22 +134,22 @@ exports.createLocalisationVariantGroup = {
     ) {
         delete project.getPBXObject('PBXVariantGroup');
 
-        var localizationVariantGp = project.addLocalizationVariantGroup(
+        const localizationVariantGp = project.addLocalizationVariantGroup(
             'InfoPlist.strings'
         );
 
-        var resourceGroupKey = project.findPBXGroupKey({ name: 'Resources' });
-        var resourceGroup = project.getPBXGroupByKey(resourceGroupKey);
-        var foundInResourcesGroup = findChildInGroup(
+        const resourceGroupKey = project.findPBXGroupKey({ name: 'Resources' });
+        const resourceGroup = project.getPBXGroupByKey(resourceGroupKey);
+        const foundInResourcesGroup = findChildInGroup(
             resourceGroup,
             localizationVariantGp.fileRef
         );
         test.ok(foundInResourcesGroup);
 
-        var foundInResourcesBuildPhase = false;
-        var sources = project.pbxResourcesBuildPhaseObj();
-        for (var i = 0, j = sources.files.length; i < j; i++) {
-            var file = sources.files[i];
+        let foundInResourcesBuildPhase = false;
+        const sources = project.pbxResourcesBuildPhaseObj();
+        for (let i = 0, j = sources.files.length; i < j; i++) {
+            const file = sources.files[i];
             if (file.value === localizationVariantGp.uuid) {
                 foundInResourcesBuildPhase = true;
             }
@@ -162,33 +162,33 @@ exports.createLocalisationVariantGroup = {
 
 exports.addResourceFileToLocalisationGroup = {
     'should add resource file to the TestVariantGroup group': function (test) {
-        var infoPlistVarGp = project.addLocalizationVariantGroup(
+        const infoPlistVarGp = project.addLocalizationVariantGroup(
             'InfoPlist.strings'
         );
-        var testKey = infoPlistVarGp.fileRef;
-        var file = project.addResourceFile(
+        const testKey = infoPlistVarGp.fileRef;
+        const file = project.addResourceFile(
             'Resources/en.lproj/Localization.strings',
             { variantGroup: true },
             testKey
         );
 
-        var foundInLocalisationVariantGroup = findChildInGroup(
+        const foundInLocalisationVariantGroup = findChildInGroup(
             project.getPBXVariantGroupByKey(testKey),
             file.fileRef
         );
         test.ok(foundInLocalisationVariantGroup);
 
-        var foundInResourcesBuildPhase = false;
-        var sources = project.pbxResourcesBuildPhaseObj();
-        for (var i = 0, j = sources.files.length; i < j; i++) {
-            var sourceFile = sources.files[i];
+        let foundInResourcesBuildPhase = false;
+        const sources = project.pbxResourcesBuildPhaseObj();
+        for (let i = 0, j = sources.files.length; i < j; i++) {
+            const sourceFile = sources.files[i];
             if (sourceFile.value === file.fileRef) {
                 foundInResourcesBuildPhase = true;
             }
         }
         test.ok(!foundInResourcesBuildPhase);
 
-        var buildFileSection = project.pbxBuildFileSection();
+        const buildFileSection = project.pbxBuildFileSection();
         test.ok(buildFileSection[file.uuid] === undefined);
 
         test.done();
@@ -199,16 +199,16 @@ exports.removeResourceFileFromGroup = {
     'should add resource file then remove resource file from Localizable.strings group': function (
         test
     ) {
-        var testKey = project.findPBXVariantGroupKey({
+        const testKey = project.findPBXVariantGroupKey({
             name: 'Localizable.strings'
         });
-        var file = project.addResourceFile(
+        const file = project.addResourceFile(
             'Resources/zh.lproj/Localization.strings',
             {},
             testKey
         );
 
-        var foundInGroup = findChildInGroup(
+        let foundInGroup = findChildInGroup(
             project.getPBXVariantGroupByKey(testKey),
             file.fileRef
         );
@@ -220,7 +220,7 @@ exports.removeResourceFileFromGroup = {
             testKey
         );
 
-        var foundInGroup = findChildInGroup(
+        foundInGroup = findChildInGroup(
             project.getPBXVariantGroupByKey(testKey),
             file.fileRef
         );

--- a/test/xcode5searchPaths.js
+++ b/test/xcode5searchPaths.js
@@ -22,33 +22,33 @@ var xcode5proj = require('./fixtures/library-search-paths'),
     proj = new pbx('.'),
     libPoop = { path: 'some/path/poop.a' };
 
-function cleanHash() {
+function cleanHash () {
     return JSON.parse(xcode5projStr);
 }
 
 exports.setUp = function (callback) {
     proj.hash = cleanHash();
     callback();
-}
+};
 
 var PRODUCT_NAME = '"$(TARGET_NAME)"';
 
 exports.addAndRemoveToFromLibrarySearchPaths = {
-    'add should add the path to each configuration section':function(test) {
+    'add should add the path to each configuration section': function (test) {
         var expected = '"\\"$(SRCROOT)/$(TARGET_NAME)/some/path\\""',
             config = proj.pbxXCBuildConfigurationSection(),
-            ref, lib, refSettings;
+            ref,
+            lib,
+            refSettings;
 
         proj.addToLibrarySearchPaths(libPoop);
 
         for (ref in config) {
-            if (ref.indexOf('_comment') > -1)
-                continue;
+            if (ref.indexOf('_comment') > -1) continue;
 
             refSettings = config[ref].buildSettings;
 
-            if (refSettings.PRODUCT_NAME != PRODUCT_NAME)
-                continue;
+            if (refSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
 
             lib = refSettings.LIBRARY_SEARCH_PATHS;
             test.equal(lib[1], expected);
@@ -56,7 +56,9 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
         test.done();
     },
 
-    'remove should remove from the path to each configuration section':function(test) {
+    'remove should remove from the path to each configuration section': function (
+        test
+    ) {
         var config, ref, lib;
 
         proj.addToLibrarySearchPaths(libPoop);
@@ -64,12 +66,18 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
 
         config = proj.pbxXCBuildConfigurationSection();
         for (ref in config) {
-            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            if (
+                ref.indexOf('_comment') > -1 ||
+                config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME
+            )
+                continue;
 
             lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
             test.ok(lib.length === 1);
-            test.ok(lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') == -1);
+            test.ok(
+                lib[0].indexOf('$(SRCROOT)/KitchenSinktablet/some/path') == -1
+            );
         }
         test.done();
     }
-}
+};

--- a/test/xcode5searchPaths.js
+++ b/test/xcode5searchPaths.js
@@ -15,12 +15,12 @@
  under the License.
  */
 
-var xcode5proj = require('./fixtures/library-search-paths'),
-    xcode5projStr = JSON.stringify(xcode5proj),
-    pbx = require('../lib/pbxProject'),
-    pbxFile = require('../lib/pbxFile'),
-    proj = new pbx('.'),
-    libPoop = { path: 'some/path/poop.a' };
+const xcode5proj = require('./fixtures/library-search-paths');
+const xcode5projStr = JSON.stringify(xcode5proj);
+const pbx = require('../lib/pbxProject');
+const pbxFile = require('../lib/pbxFile');
+const proj = new pbx('.');
+const libPoop = { path: 'some/path/poop.a' };
 
 function cleanHash () {
     return JSON.parse(xcode5projStr);
@@ -31,15 +31,15 @@ exports.setUp = function (callback) {
     callback();
 };
 
-var PRODUCT_NAME = '"$(TARGET_NAME)"';
+const PRODUCT_NAME = '"$(TARGET_NAME)"';
 
 exports.addAndRemoveToFromLibrarySearchPaths = {
     'add should add the path to each configuration section': function (test) {
-        var expected = '"\\"$(SRCROOT)/$(TARGET_NAME)/some/path\\""',
-            config = proj.pbxXCBuildConfigurationSection(),
-            ref,
-            lib,
-            refSettings;
+        const expected = '"\\"$(SRCROOT)/$(TARGET_NAME)/some/path\\""';
+        const config = proj.pbxXCBuildConfigurationSection();
+        let ref;
+        let lib;
+        let refSettings;
 
         proj.addToLibrarySearchPaths(libPoop);
 
@@ -59,12 +59,13 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
     'remove should remove from the path to each configuration section': function (
         test
     ) {
-        var config, ref, lib;
+        let ref, lib;
 
         proj.addToLibrarySearchPaths(libPoop);
         proj.removeFromLibrarySearchPaths(libPoop);
 
-        config = proj.pbxXCBuildConfigurationSection();
+        const config = proj.pbxXCBuildConfigurationSection();
+
         for (ref in config) {
             if (
                 ref.indexOf('_comment') > -1 ||

--- a/test/xcode5searchPaths.js
+++ b/test/xcode5searchPaths.js
@@ -15,7 +15,7 @@
  under the License.
  */
 
-var xcode5proj = require('./fixtures/library-search-paths')
+var xcode5proj = require('./fixtures/library-search-paths'),
     xcode5projStr = JSON.stringify(xcode5proj),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),


### PR DESCRIPTION
Here are some updates that introduce npm scripts to run both `eslint` and `prettier-eslint`, with semistandard-like configuration ([`standard`](https://npmjs.com/package/standard) with semicolons *required*). The `prettier` script actually runs [`prettier-eslint-cli`](https://www.npmjs.com/package/prettier-eslint-cli) which runs both `prettier` and `eslint --fix` in order to format the code in a nice, consistent manner according to the configured `eslint` rules.

Before using `prettier` I had to disable a number of `eslint` rules in order for `eslint` to succeed on the code in this project. The `prettier` script was able to resolve the issues with the majority of the rules I had to disable, and I have made progress on resolving more of the eslint issues.

I think this approach is much better than using [`eslint-config-prettier`](https://www.npmjs.com/package/eslint-config-prettier), which actually disables a number of rules in order to maintain compatibility with `prettier`. The one major disadvantage I see is that we do not see the changes wanted by `prettier` in the `eslint` results.

Some TODO items remaining:
* [ ] enforce maximum code width of 78-80 characters using `max-len` rule, as the `prettier` task does in the output formatting, with a few issues to be resolved in `lib` & `test`
* [ ] resolve a few more eslint issues in `lib` for rules that are disabled in `lib/.eslintrc.yml`
* [ ] resolve some eslint issues in `test` for rules that are disabled in `test/.eslintrc.yml`
* [ ] move `eslint` task from `.travis.yml` to npm `eslint` script once we drop support for Node.js pre-6.0

Note these changes are coming from a wip branch. I am planning to raise a new PR once these changes are ready for review and possible merge.

/cc @n1ru4l