### PR TITLE
Update writeObjectsSections to match current Xcode format

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,7 +20,6 @@
 -->
 # Cordova-node-xcode Release Notes
 
-
 ### 2.0.0 (Jan 15, 2019)
 * Updated to use ECMAScript 2015 Object.assign. ([#14](https://github.com/apache/cordova-node-xcode/pull/14))
 * fix: simple-plist@1 update in dependencies ([#30](https://github.com/apache/cordova-node-xcode/pull/30))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,8 @@
 -->
 # Cordova-node-xcode Release Notes
 
+* Updated `objects = {` to be followed by a blank line, matching current Xcode layout ([#42](https://github.com/apache/cordova-node-xcode/pull/46))
+
 ### 2.0.0 (Jan 15, 2019)
 * Updated to use ECMAScript 2015 Object.assign. ([#14](https://github.com/apache/cordova-node-xcode/pull/14))
 * fix: simple-plist@1 update in dependencies ([#30](https://github.com/apache/cordova-node-xcode/pull/30))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,7 +20,7 @@
 -->
 # Cordova-node-xcode Release Notes
 
-* Updated `objects = {` to be followed by a blank line, matching current Xcode layout ([#42](https://github.com/apache/cordova-node-xcode/pull/46))
+* Updated `objects = {` to be followed by a blank line, matching current Xcode layout ([#46](https://github.com/apache/cordova-node-xcode/pull/46))
 
 ### 2.0.0 (Jan 15, 2019)
 * Updated to use ECMAScript 2015 Object.assign. ([#14](https://github.com/apache/cordova-node-xcode/pull/14))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,7 +20,6 @@
 -->
 # Cordova-node-xcode Release Notes
 
-* Updated `objects = {` to be followed by a blank line, matching current Xcode layout ([#46](https://github.com/apache/cordova-node-xcode/pull/46))
 
 ### 2.0.0 (Jan 15, 2019)
 * Updated to use ECMAScript 2015 Object.assign. ([#14](https://github.com/apache/cordova-node-xcode/pull/14))

--- a/lib/pbxWriter.js
+++ b/lib/pbxWriter.js
@@ -178,15 +178,10 @@ pbxWriter.prototype.writeObject = function (object) {
 }
 
 pbxWriter.prototype.writeObjectsSections = function (objects) {
-    var first = true,
-        key, obj;
+    var key, obj;
 
     for (key in objects) {
-        if (!first) {
-            this.writeFlush("\n")
-        } else {
-            first = false;
-        }
+        this.writeFlush("\n")
 
         obj = objects[key];
 

--- a/test/parser/projects/build-config.pbxproj
+++ b/test/parser/projects/build-config.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 45;
 	objects = {
+
 /* Begin XCBuildConfiguration section */
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;

--- a/test/parser/projects/build-files.pbxproj
+++ b/test/parser/projects/build-files.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 45;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };

--- a/test/parser/projects/empty-groups.pbxproj
+++ b/test/parser/projects/empty-groups.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 45;
 	objects = {
+
 /* Begin PBXFileReference section */
 /* End PBXFileReference section */
 /* Begin PBXBuildFile section */

--- a/test/parser/projects/expected/with_omit_empty_values_disabled_expected.pbxproj
+++ b/test/parser/projects/expected/with_omit_empty_values_disabled_expected.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };

--- a/test/parser/projects/expected/with_omit_empty_values_enabled_expected.pbxproj
+++ b/test/parser/projects/expected/with_omit_empty_values_enabled_expected.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };

--- a/test/parser/projects/fail.pbxproj
+++ b/test/parser/projects/fail.pbxproj
@@ -7,6 +7,7 @@ THIS SHOULD FAIL TO PARSE
     objectVersion = 45;
     rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
     objects = {
+
 /* Begin PBXTargetDependency section */
         301BF551109A68C00062928A /* PBXTargetDependency */ = {
             isa = PBXTargetDependency;

--- a/test/parser/projects/file-references.pbxproj
+++ b/test/parser/projects/file-references.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 45;
 	objects = {
+
 /* Begin PBXFileReference section */
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };

--- a/test/parser/projects/header-search.pbxproj
+++ b/test/parser/projects/header-search.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin XCBuildConfiguration section */
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;

--- a/test/parser/projects/nested-object.pbxproj
+++ b/test/parser/projects/nested-object.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 45;
 	objects = {
+
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;

--- a/test/parser/projects/section-entries.pbxproj
+++ b/test/parser/projects/section-entries.pbxproj
@@ -6,6 +6,7 @@
     objectVersion = 45;
     rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
     objects = {
+
 /* Begin PBXVariantGroup section */
 		1F766FDC13BBADB100FB74C0 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;

--- a/test/parser/projects/section-split.pbxproj
+++ b/test/parser/projects/section-split.pbxproj
@@ -6,6 +6,7 @@
     objectVersion = 45;
     rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
     objects = {
+
 /* Begin PBXTargetDependency section */
         301BF551109A68C00062928A /* PBXTargetDependency */ = {
             isa = PBXTargetDependency;

--- a/test/parser/projects/section.pbxproj
+++ b/test/parser/projects/section.pbxproj
@@ -6,6 +6,7 @@
     objectVersion = 45;
     rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
     objects = {
+
 /* Begin PBXTargetDependency section */
         301BF551109A68C00062928A /* PBXTargetDependency */ = {
             isa = PBXTargetDependency;

--- a/test/parser/projects/two-sections.pbxproj
+++ b/test/parser/projects/two-sections.pbxproj
@@ -6,6 +6,7 @@
     objectVersion = 45;
     rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
     objects = {
+
 /* Begin PBXTargetDependency section */
 		301BF551109A68C00062928A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/test/parser/projects/with_omit_empty_values_disabled.pbxproj
+++ b/test/parser/projects/with_omit_empty_values_disabled.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };

--- a/test/parser/projects/with_omit_empty_values_enabled.pbxproj
+++ b/test/parser/projects/with_omit_empty_values_enabled.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };


### PR DESCRIPTION
We've been noticing some thrash where a blank line gets deleted or re-added when adding new NativeModules to our react-native project. 

Under the hood, several of our tools are using this npm package. After some experiments, I was able to figure out that current Xcode versions will automatically insert an extra blank line after the `objects = {` section of the Xcode project.

Looking at the source-code of this tool, I found that 7 years ago this was an intentional feature: https://github.com/apache/cordova-node-xcode/blob/415924977a8c6da5dda2cd2cfe40d67b365b1ea3/lib/pbxWriter.js#L185-L189

With the current release version of Xcode, and indeed several previous versions of Xcode 10 and possibly later versions of Xcode 9, when Xcode writes out the project.pbxproj file, it will insert this blank line.

This PR brings cordova-node-xcode into line with that style.
Tested on Xcode Version 10.1 (10B61)

> Aside: 15 of the 19 project fixtures had the old-style, while 4 of the fixtures had the new style, so either we have some unused fixtures, or some fixtures aren't using the pbxWriter for what they're testing?