### PR TITLE
Travis CI now on Linux & macOS ("osx")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ node_js:
   - 10
   - 12
 
+os:
+  - linux
+  - osx
+
 install:
   - nvm --version
   - node --version


### PR DESCRIPTION
This is a quick fix that both adds testing on mac OS and gives us a green build.