### PR TITLE
Add imports for per-file nodeunit testing

### DIFF
--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -18,6 +18,7 @@
 var fullProject = require('./fixtures/full-project')
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
 
 function cleanHash() {


### PR DESCRIPTION
I noticed that when testing a file with `nodeunit` individually, some were failing. This PR resolves that issue and allows for single-file testing with `nodeunit`.

```
-> node_modules/.bin/nodeunit test/addTarget.js

addTarget.js
✔ addTarget - should throw when target name is missing
✔ addTarget - should throw when target type missing
✔ addTarget - should create a new target
✖ addTarget - should create a new target and add source, framework, resource and header files and the corresponding build phases

ReferenceError: pbxFile is not defined
    at Object.should create a new target and add source, framework, resource and header files and the corresponding build phases (/Users/me/repos/cordova-node-xcode/test/addTarget.js:85:44)
...
```

The tests would still pass when running all at once (`npm run test`), so this seems to only be needed when testing a single file at a time. I assume running the full suite doesn't cause issues because once one file `require`s the necessary import, other ones can reference it as well--but it might be worth some future effort into why `nodeunit` is allowing bleedover from one test to another.

First mentioned in https://github.com/apache/cordova-node-xcode/pull/66#discussion_r335777801.