### PR TITLE
cleanup: remove internal propReplace function not needed

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1491,20 +1491,6 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
 
 };
 
-// helper recursive prop search+replace
-function propReplace(obj, prop, value) {
-    var o = {};
-    for (var p in obj) {
-        if (o.hasOwnProperty.call(obj, p)) {
-            if (typeof obj[p] == 'object' && !Array.isArray(obj[p])) {
-                propReplace(obj[p], prop, value);
-            } else if (p == prop) {
-                obj[p] = value;
-            }
-        }
-    }
-}
-
 // helper object creation functions
 function pbxBuildFileObj(file) {
     var obj = Object.create(null);


### PR DESCRIPTION
I discovered this while looking through mutation testing results of WatchKit 2 support (#56).

See PR #61 for more details of proposed mutation testing updates.