### PR TITLE
Test existing WatchKit support

### DIFF
--- a/test/addWatchApp.js
+++ b/test/addWatchApp.js
@@ -1,0 +1,139 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ 'License'); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+var TARGET_NAME = 'TestWatchApp',
+    TARGET_TYPE = 'watch2_app',
+    TARGET_SUBFOLDER_NAME = 'TestWatchAppFiles';
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.addWatchApp = {
+    'should create a new watch app target': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.done();
+    },
+    'should create a new watch app target without needing a subfolder name': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.done();
+    },
+    'should create a new watch app target and add source, framework, resource and header files and the corresponding build phases': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME),
+            options = { 'target' : target.uuid };
+
+        var sourceFile = proj.addSourceFile('Plugins/file.m', options),
+            sourcePhase = proj.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid),
+            resourceFile = proj.addResourceFile('assets.bundle', options),
+            resourcePhase = proj.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', target.uuid),
+            frameworkFile = proj.addFramework('libsqlite3.dylib', options);
+            frameworkPhase = proj.addBuildPhase([], 'PBXFrameworkBuildPhase', 'Frameworks', target.uuid),
+            headerFile = proj.addHeaderFile('file.h', options);
+
+        test.ok(sourcePhase);
+        test.ok(resourcePhase);
+        test.ok(frameworkPhase);
+
+        test.equal(sourceFile.constructor, pbxFile);
+        test.equal(resourceFile.constructor, pbxFile);
+        test.equal(frameworkFile.constructor, pbxFile);
+        test.equal(headerFile.constructor, pbxFile);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.done();
+    },
+    'should create a new watch app target and add watch build phase': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp2"');
+
+        var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Watch Content', target.uuid);
+
+        test.ok(buildPhase);
+        test.ok(buildPhase.files);
+        test.equal(buildPhase.files.length, 1);
+        test.ok(buildPhase.dstPath);
+        test.equal(buildPhase.dstPath, '"$(CONTENTS_FOLDER_PATH)/Watch"');
+        test.equal(buildPhase.dstSubfolderSpec, 16);
+
+        test.done();
+    }
+}

--- a/test/addWatchApp.js
+++ b/test/addWatchApp.js
@@ -35,7 +35,7 @@ exports.setUp = function (callback) {
 }
 
 exports.addWatchApp = {
-    'should create a new watch app target': function (test) {
+    'should create a new watch app target with the correct product type': function (test) {
         var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
 
         test.ok(typeof target == 'object');
@@ -51,9 +51,11 @@ exports.addWatchApp = {
         test.ok(target.pbxNativeTarget.buildRules);
         test.ok(target.pbxNativeTarget.dependencies);
 
+        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp"');
+
         test.done();
     },
-    'should create a new watch app target without needing a subfolder name': function (test) {
+    'should create a new watch app target with the correct product type, without needing a subfolder name': function (test) {
         var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
 
         test.ok(typeof target == 'object');
@@ -68,6 +70,8 @@ exports.addWatchApp = {
         test.ok(target.pbxNativeTarget.buildPhases);
         test.ok(target.pbxNativeTarget.buildRules);
         test.ok(target.pbxNativeTarget.dependencies);
+
+        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp"');
 
         test.done();
     },
@@ -104,27 +108,6 @@ exports.addWatchApp = {
         test.ok(target.pbxNativeTarget.buildPhases);
         test.ok(target.pbxNativeTarget.buildRules);
         test.ok(target.pbxNativeTarget.dependencies);
-
-        test.done();
-    },
-    'should create a new watch app target that has the correct product type': function (test) {
-        // (with no subfolder name)
-        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
-
-        test.ok(typeof target == 'object');
-        test.ok(target.uuid);
-        test.ok(target.pbxNativeTarget);
-        test.ok(target.pbxNativeTarget.isa);
-        test.ok(target.pbxNativeTarget.name);
-        test.ok(target.pbxNativeTarget.productName);
-        test.ok(target.pbxNativeTarget.productReference);
-        test.ok(target.pbxNativeTarget.productType);
-        test.ok(target.pbxNativeTarget.buildConfigurationList);
-        test.ok(target.pbxNativeTarget.buildPhases);
-        test.ok(target.pbxNativeTarget.buildRules);
-        test.ok(target.pbxNativeTarget.dependencies);
-
-        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp"');
 
         test.done();
     }

--- a/test/addWatchApp.js
+++ b/test/addWatchApp.js
@@ -26,7 +26,7 @@ function cleanHash() {
 }
 
 var TARGET_NAME = 'TestWatchApp',
-    TARGET_TYPE = 'watch2_app',
+    TARGET_TYPE = 'watch_app',
     TARGET_SUBFOLDER_NAME = 'TestWatchAppFiles';
 
 exports.setUp = function (callback) {
@@ -107,7 +107,8 @@ exports.addWatchApp = {
 
         test.done();
     },
-    'should create a new watch app target and add watch build phase': function (test) {
+    'should create a new watch app target that has the correct product type': function (test) {
+        // (with no subfolder name)
         var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
 
         test.ok(typeof target == 'object');
@@ -123,16 +124,7 @@ exports.addWatchApp = {
         test.ok(target.pbxNativeTarget.buildRules);
         test.ok(target.pbxNativeTarget.dependencies);
 
-        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp2"');
-
-        var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Watch Content', target.uuid);
-
-        test.ok(buildPhase);
-        test.ok(buildPhase.files);
-        test.equal(buildPhase.files.length, 1);
-        test.ok(buildPhase.dstPath);
-        test.equal(buildPhase.dstPath, '"$(CONTENTS_FOLDER_PATH)/Watch"');
-        test.equal(buildPhase.dstSubfolderSpec, 16);
+        test.equal(target.pbxNativeTarget.productType, '"com.apple.product-type.application.watchapp"');
 
         test.done();
     }

--- a/test/addWatchExtension.js
+++ b/test/addWatchExtension.js
@@ -1,0 +1,143 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ 'License'); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+var TARGET_NAME = 'TestWatchExtension',
+    TARGET_TYPE = 'watch2_extension',
+    TARGET_SUBFOLDER_NAME = 'TestWatchExtensionFiles';
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.addWatchExtension = {
+    'should create a new watch extension target': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.done();
+    },
+    'should create a new watch extension target and add source, framework, resource and header files and the corresponding build phases': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME),
+            options = { 'target' : target.uuid };
+
+        var sourceFile = proj.addSourceFile('Plugins/file.m', options),
+            sourcePhase = proj.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid),
+            resourceFile = proj.addResourceFile('assets.bundle', options),
+            resourcePhase = proj.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', target.uuid),
+            frameworkFile = proj.addFramework('libsqlite3.dylib', options);
+            frameworkPhase = proj.addBuildPhase([], 'PBXFrameworkBuildPhase', 'Frameworks', target.uuid),
+            headerFile = proj.addHeaderFile('file.h', options);
+
+        test.ok(sourcePhase);
+        test.ok(resourcePhase);
+        test.ok(frameworkPhase);
+
+        test.equal(sourceFile.constructor, pbxFile);
+        test.equal(resourceFile.constructor, pbxFile);
+        test.equal(frameworkFile.constructor, pbxFile);
+        test.equal(headerFile.constructor, pbxFile);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        test.done();
+    },
+    'should not create a new watch extension build phase if no watch app exists': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
+
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+
+        var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed App Extensions', target.uuid)
+
+        test.ok(!buildPhase);
+
+        test.done();
+    },
+    'should create a new watch extension build phase if watch app exists': function (test) {
+        proj.addTarget('TestWatchApp', 'watch2_app');
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
+
+        var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed App Extensions', target.uuid)
+
+        test.ok(buildPhase);
+        test.ok(buildPhase.files);
+        test.equal(buildPhase.files.length, 1);
+        test.ok(buildPhase.dstPath);
+        test.equal(buildPhase.dstSubfolderSpec, 13);
+
+        test.done();
+    },
+    'should create a new watch extension and add to existing watch app build phase and dependency': function (test) {
+        var watchApp = proj.addTarget('TestWatchApp', 'watch2_app');
+
+        var nativeTargets = proj.pbxNativeTargetSection();
+
+        test.equal(nativeTargets[watchApp.uuid].buildPhases.length, 0);
+        test.equal(nativeTargets[watchApp.uuid].dependencies.length, 0);
+
+        proj.addTarget(TARGET_NAME, TARGET_TYPE);
+
+        test.equal(nativeTargets[watchApp.uuid].buildPhases.length, 1);
+        test.equal(nativeTargets[watchApp.uuid].dependencies.length, 1);
+
+        test.done();
+    }
+}

--- a/test/addWatchExtension.js
+++ b/test/addWatchExtension.js
@@ -26,7 +26,7 @@ function cleanHash() {
 }
 
 var TARGET_NAME = 'TestWatchExtension',
-    TARGET_TYPE = 'watch2_extension',
+    TARGET_TYPE = 'watch_extension',
     TARGET_SUBFOLDER_NAME = 'TestWatchExtensionFiles';
 
 exports.setUp = function (callback) {
@@ -108,35 +108,6 @@ exports.addWatchExtension = {
         var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed App Extensions', target.uuid)
 
         test.ok(!buildPhase);
-
-        test.done();
-    },
-    'should create a new watch extension build phase if watch app exists': function (test) {
-        proj.addTarget('TestWatchApp', 'watch2_app');
-        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE);
-
-        var buildPhase = proj.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed App Extensions', target.uuid)
-
-        test.ok(buildPhase);
-        test.ok(buildPhase.files);
-        test.equal(buildPhase.files.length, 1);
-        test.ok(buildPhase.dstPath);
-        test.equal(buildPhase.dstSubfolderSpec, 13);
-
-        test.done();
-    },
-    'should create a new watch extension and add to existing watch app build phase and dependency': function (test) {
-        var watchApp = proj.addTarget('TestWatchApp', 'watch2_app');
-
-        var nativeTargets = proj.pbxNativeTargetSection();
-
-        test.equal(nativeTargets[watchApp.uuid].buildPhases.length, 0);
-        test.equal(nativeTargets[watchApp.uuid].dependencies.length, 0);
-
-        proj.addTarget(TARGET_NAME, TARGET_TYPE);
-
-        test.equal(nativeTargets[watchApp.uuid].buildPhases.length, 1);
-        test.equal(nativeTargets[watchApp.uuid].dependencies.length, 1);
 
         test.done();
     }


### PR DESCRIPTION
Tests originally proposed by @l3ender in PR #56, adapted to test the existing WatchKit support functionality.

I think this testing should be done before we add WatchKit 2 support, as proposed in PR #56.

Here is the report from the Stryker mutator tool:

- https://chrisbrody.com/node-xcode-mutation-test-existing-watch-kit-support/index.html

Note that WatchKit extension functionality in `filetypeForProducttype` (internal function in `lib/pbxProject.js`) is still not covered by these updates (see issue #70).

/cc @l3ender - review and feedback would be appreciated