### PR TITLE
ci(travis): removes Node.js v6 and v8 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ git:
   depth: 10
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 


### PR DESCRIPTION
Ref https://github.com/apache/cordova/issues/79