### PR TITLE
chore: bump version to 3.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Apache Software Foundation",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "2.1.1-dev",
+  "version": "3.0.0-dev",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/apache/cordova-node-xcode.git"


### PR DESCRIPTION
# Motivation and Context

Prepare repo for next major development and release to unblock #90 - also part of https://github.com/apache/cordova/issues/79

## Description

Bump repo's version to 6.0.0-dev in:
* package.json

Testing
* npm t

Checklist

* [x] I've run the tests to see all new and existing tests pass
