### PR TITLE
chore(npm): use short notation for repo & bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "parser for xcodeproj/project.pbxproj files",
   "version": "3.0.0-dev",
   "main": "index.js",
-  "repository": {
-    "url": "https://github.com/apache/cordova-node-xcode.git"
-  },
+  "repository": "github:apache/cordova-node-xcode",
+  "bugs": "https://github.com/apache/cordova-node-xcode/issues",
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
Update `package.json`

* Add `bugs` property.
* Use shorthand notation for both `repository` & `bugs`