### PR TITLE
Need to check for object existence

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1679,7 +1679,7 @@ function correctForFrameworksPath(file, project) {
 function correctForPath(file, project, group) {
     var r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
-    if (project.pbxGroupByName(group).path)
+    if (project.pbxGroupByName(group) && project.pbxGroupByName(group).path)
         file.path = file.path.replace(r_group_dir, '');
 
     return file;


### PR DESCRIPTION
When this code runs and a folder called "Resources" is not in the XCode project this call fails.

Need to check for object existence before accessing path.

There should be no impact from this change only preventing a run time error when a folder is not present