### PR TITLE
Fix test failure on Windows

### DIFF
--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -110,7 +110,7 @@ exports.addTarget = {
         test.ok(target.pbxNativeTarget.buildPhases);
         test.ok(target.pbxNativeTarget.buildRules);
         test.ok(target.pbxNativeTarget.dependencies);
-  
+
         test.done();
     },
     'should add debug and release configurations to build configuration list': function (test) {

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -17,6 +17,7 @@
 
 var fullProject = require('./fixtures/full-project')
     fullProjectStr = JSON.stringify(fullProject),
+    path = require('path'),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),
     proj = new pbx('.');
@@ -138,7 +139,7 @@ exports.addTarget = {
                 test.equal(debugConfig[0], '"DEBUG=1"');
                 test.equal(debugConfig[1], '"$(inherited)"');
             }
-            test.equal(pbxConfig.buildSettings['INFOPLIST_FILE'], '"' + TARGET_SUBFOLDER_NAME + '/' + TARGET_SUBFOLDER_NAME + '-Info.plist"');
+            test.equal(pbxConfig.buildSettings['INFOPLIST_FILE'], '"' + TARGET_SUBFOLDER_NAME + path.sep + TARGET_SUBFOLDER_NAME + '-Info.plist"');
             test.equal(pbxConfig.buildSettings['LD_RUNPATH_SEARCH_PATHS'], '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"');
             test.equal(pbxConfig.buildSettings['PRODUCT_NAME'], '"' + TARGET_NAME + '"');
             test.equal(pbxConfig.buildSettings['SKIP_INSTALL'], 'YES');

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -230,7 +230,7 @@ exports['path'] = {
 }
 
 exports['settings'] = {
-   'should not be defined by default': function (test) {
+    'should not be defined by default': function (test) {
       var sourceFile = new pbxFile('social.framework');
 
       test.equal(undefined, sourceFile.settings);


### PR DESCRIPTION
`git clone` and `npm cit` on Windows

1 test is failing: `"FAILURES: 2/1599 assertions failed"`
```
× addTarget - should add debug and release configurations to build configuration list
AssertionError: '"TestExtensionFiles\\TestExtensionFiles-Info.plist"' == '"TestExtensionFiles/TestExtensionFiles-Info.plist"'
```

Using a platform-specific path separator resolves this path mismatch: `"OK: 1599 assertions"`