### PR TITLE
fix pbxProject.addBuildPhase

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -916,7 +916,7 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
             buildFile = buildFileSection[buildFileKey];
         fileReference = fileReferenceSection[buildFile.fileRef];
 
-        if (!fileReference) continue;
+        if (!fileReference || !fileReference.path) continue;
 
         var pbxFileObj = new pbxFile(fileReference.path);
 
@@ -1148,7 +1148,7 @@ pbxProject.prototype.updateBuildProperty = function(prop, value, build, targetNa
             }
         }
     }
-    
+
     var configs = this.pbxXCBuildConfigurationSection();
     for (var configName in configs) {
         if (!COMMENT_KEY.test(configName)) {
@@ -2091,7 +2091,7 @@ pbxProject.prototype.getBuildProperty = function(prop, build, targetName) {
             }
         }
     }
-    
+
     var configs = this.pbxXCBuildConfigurationSection();
     for (var configName in configs) {
         if (!COMMENT_KEY.test(configName)) {


### PR DESCRIPTION
addBuildPhase method fail when pbx file contains file references without path, it happen with cordova-ios 7.
The file reference without path is ``[Object: null prototype] {
  isa: 'PBXFileReference',
  lastKnownFileType: 'folder.assetcatalog',
  name: 'Assets.xcassets',
  sourceTree: '"<group>"'
}``