### PR TITLE
Add support for 'alwaysOutOfDate' PBX Shell Script property

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1644,6 +1644,10 @@ function pbxShellScriptBuildPhaseObj(obj, options, phaseName) {
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
 
+    if (options.alwaysOutOfDate !== null) {
+        obj.alwaysOutOfDate = options.alwaysOutOfDate;
+    }
+
     return obj;
 }
 

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -194,4 +194,26 @@ exports.addBuildPhase = {
         test.equal(buildPhase.shellScript, '"echo \\"hello world!\\""');
         test.done();
     },
+    'should add the PBXBuildPhase with alwaysOutOfDate property': function (test) {
+        var options = {
+            shellPath: '/bin/sh',
+            shellScript: 'test',
+            alwaysOutOfDate: true
+        };
+
+        var buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+        test.equal(buildPhase.shellPath, '/bin/sh');
+        test.equal(buildPhase.shellScript, '"test"');
+        test.equal(buildPhase.alwaysOutOfDate, 1);
+        test.done();
+    },
+    'should add the PBXBuildPhase without alwaysOutOfDate property': function (test) {
+        var options = {shellPath: '/bin/sh', shellScript: 'test'};
+
+        var buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+        test.equal(buildPhase.shellPath, '/bin/sh');
+        test.equal(buildPhase.shellScript, '"test"');
+        test.equal(buildPhase.alwaysOutOfDate, null);
+        test.done();
+    },
 }


### PR DESCRIPTION
This PR adds support for the `alwaysOutOfDate` property in PBX Shell Scripts.

Setting `alwaysOutOfDate` to `true` disables dependency analysis for the given build phase, clearing warnings such as:

```sh
Script has ambiguous dependencies causing it to run on every build
```

Since by default the property is not added to the PBX project file by Xcode, I have decided to write it down in the PBX file only if explicitly specified in the `pbxShellScriptBuildPhaseObj` options, hence the null check.