### PR TITLE
ci: Drop NodeJS 10, 12, 14. Added 18, 20, 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Updates NodeJS Matrix in the CI to drop old NodeJS versions and replaced them with:

- 18.x (In maintenance until 2025)
- 20.x (Current LTS)
- 22.x (Current active, next LTS)

10, 12, 14 support was completely dropped from modern runners provided by GH so they just simply fail now, as obsevable on https://github.com/apache/cordova-node-xcode/pull/143. With that being said, I don't know if we want to make a new major release since now we are only testing completely new generations of NodeJS runtimes.