### PR TITLE
fix: strip trailing null bytes from pbxproj before parsing

### DIFF
--- a/lib/parseJob.js
+++ b/lib/parseJob.js
@@ -26,6 +26,9 @@ var fs = require('fs'),
 
 try {
     fileContents = fs.readFileSync(path, 'utf-8');
+    // Strip trailing null bytes that can appear from filesystem-level padding
+    // (e.g. Bun runtime file writes on APFS). The PEG parser rejects \0 characters.
+    fileContents = fileContents.replace(/\0+$/, '');
     obj = parser.parse(fileContents);
     process.send(obj);
 } catch (e) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -62,6 +62,10 @@ pbxProject.prototype.parse = function(cb) {
 pbxProject.prototype.parseSync = function() {
     var file_contents = fs.readFileSync(this.filepath, 'utf-8');
 
+    // Strip trailing null bytes that can appear from filesystem-level padding
+    // (e.g. Bun runtime file writes on APFS). The PEG parser rejects \0 characters.
+    file_contents = file_contents.replace(/\0+$/, '');
+
     this.hash = parser.parse(file_contents);
     return this;
 }


### PR DESCRIPTION
## Summary

Some runtimes (notably Bun) and filesystems (APFS) can produce files with trailing null byte padding after `fs.writeFileSync`. When the `xcode` library reads a `.pbxproj` file that has been written this way, the PEG parser fails with:

```
SyntaxError: Expected end of input but "\0" found.
```

The actual pbxproj content is valid — only trailing `\0` bytes cause the parse failure.

## Changes

- `lib/pbxProject.js` (`parseSync`): Strip trailing null bytes before passing to parser
- `lib/parseJob.js` (async `parse`): Same fix for the forked worker path

The fix is a single `.replace(/\0+$/, '')` on the file contents string, applied after `readFileSync` and before `parser.parse()`.

## Reproduction

1. Use Bun to run Expo prebuild (`bun expo prebuild --platform ios --clean`)
2. A config plugin calls `withXcodeProject` which triggers `parseSync`
3. The generated `project.pbxproj` has ~16KB of trailing null bytes
4. Parser throws `SyntaxError: Expected end of input but "\0" found`

## Test plan

- Existing tests continue to pass (no null bytes = no-op regex replace)
- Files with trailing null bytes now parse successfully