### PR TITLE
chore!: bump minimum Node.js engine to >=14.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "github:apache/cordova-node-xcode",
   "bugs": "https://github.com/apache/cordova-node-xcode/issues",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.17.0"
   },
   "dependencies": {
     "simple-plist": "^1.1.0",


### PR DESCRIPTION
Companion to #153.

`crypto.randomUUID()` — introduced to replace the `uuid` dependency in #153 — requires Node.js >=14.17.0. Node 10 and 12 have been EOL since 2021 and 2022 respectively.

This is a separate PR as requested so that #153 can be reverted independently if needed.

## Breaking change

Node <14.17.0 is no longer supported.