### PR TITLE
chore(workflow): update CI test matrix & use macos-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,54 @@ on:
     branches:
       - '*'
 
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+
+      - uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - coverage
+              - node_modules
+
+      - name: Run npm install
+        run: npm ci
+        env:
+          CI: true
+
+      - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+
   test:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, macos-26]
-        node-options: '--test-coverage-exclude="test/**/*.js"' # shared default node options
+        # Shared default node options
+        node-options: '--test-coverage-exclude="test/**/*.js"'
 
         include:
           # Override default node options for node 20.x
@@ -61,22 +95,11 @@ jobs:
           node --version
           npm --version
 
-      - uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        with:
-          languages: javascript
-          queries: security-and-quality
-          config: |
-            paths-ignore:
-              - coverage
-              - node_modules
-
       - name: npm install and test
         run: npm cit
         env:
           CI: true
           NODE_OPTIONS: ${{ matrix.node-options }}
-
-      - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-26]
+        # The "--test-coverage-exclude" flag is supported in v22.5.0 and later.
+        # By default, all matching test files are excluded from the coverage report.
+        # Only Node.js 22.x requires explicitly declaring test file exclusions.
         node:
           - version: 20.x
             options: ''
           - version: 22.x
             options: --test-coverage-exclude=test/**/*.js
           - version: 24.x
-            options: --test-coverage-exclude=test/**/*.js
+            options: ''
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,20 @@ permissions:
 
 jobs:
   test:
-    name: NodeJS ${{ matrix.node.version }} on ${{ matrix.os }}
+    name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node:
-          - version: 20.x
-          - version: 22.x
-            options: --test-coverage-exclude="test/**/*.js"
-          - version: 24.x
-        os: [ubuntu-latest, macos-15]
+        node-version: [20.x, 22.x, 24.x]
+        os: [ubuntu-latest, macos-26]
+        node-options: '--test-coverage-exclude="test/**/*.js"' # shared default node options
+
+        include:
+          # Override default node options for node 20.x
+          # The "--test-coverage-exclude" flag does not exist in node 20.x.
+          - node-version: 20.x
+            node-options: ''
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node.version }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Environment Information
         run: |
@@ -71,12 +74,13 @@ jobs:
         run: npm cit
         env:
           CI: true
+          NODE_OPTIONS: ${{ matrix.node-options }}
 
       - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         if: success()
         with:
-          name: ${{ runner.os }} node.js ${{ matrix.node.version }}
+          name: ${{ runner.os }} node.js ${{ matrix.node-version }}
           token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24.x
-
       - uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: javascript
@@ -52,11 +48,6 @@ jobs:
             paths-ignore:
               - coverage
               - node_modules
-
-      - name: Run npm install
-        run: npm ci
-        env:
-          CI: true
 
       - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
   test:
-    name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: NodeJS ${{ matrix.node.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     permissions:
@@ -69,16 +69,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, macos-26]
-        # Shared default node options
-        node-options: '--test-coverage-exclude="test/**/*.js"'
-
-        include:
-          # Override default node options for node 20.x
-          # The "--test-coverage-exclude" flag does not exist in node 20.x.
-          - node-version: 20.x
-            node-options: ''
+        node:
+          - version: 20.x
+            options: ''
+          - version: 22.x
+            options: --test-coverage-exclude=test/**/*.js
+          - version: 24.x
+            options: --test-coverage-exclude=test/**/*.js
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -88,7 +86,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node.version: ${{ matrix.node.version }}
 
       - name: Environment Information
         run: |
@@ -99,11 +97,11 @@ jobs:
         run: npm cit
         env:
           CI: true
-          NODE_OPTIONS: ${{ matrix.node-options }}
+          NODE_OPTIONS: ${{ matrix.node.options }}
 
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         if: success()
         with:
-          name: ${{ runner.os }} node.js ${{ matrix.node-version }}
+          name: ${{ runner.os }} node.js ${{ matrix.node.version }}
           token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
- Update CI Test Matrix testing job
- Split CodeQL to its own job in the CI workflow
- Use `macos-26`