### PR TITLE
fix: shallow-merging nested objects for split sections

### DIFF
--- a/lib/parser/pbxproj.js
+++ b/lib/parser/pbxproj.js
@@ -178,9 +178,47 @@ function peg$parse(input, options) {
       peg$c6 = function() { return Object.create(null) },
       peg$c7 = function(list) {
               var returnObject = list[0][0];
-              for(var i = 1; i < list.length; i++){
+
+              for (var i = 1; i < list.length; i++) {
                   var another = list[i][0];
-                  returnObject = Object.assign(returnObject, another);
+
+                  /*
+                   * Ensure previously parsed section entries are not lost
+                   *
+                   * Example:
+                   *
+                   * If "returnObject" contains:
+                   *
+                   *  {
+                   *      PBXTargetDependency: {
+                   *          'A': {},
+                   *          'A_comment': 'PBXTargetDependency'
+                   *      }
+                   *  }
+                   *
+                   * And "another" contains:
+                   *
+                   *  {
+                   *      PBXTargetDependency: {
+                   *          'B': {},
+                   *          'B_comment': 'PBXTargetDependency'
+                   *      }
+                   *  }
+                   *
+                   * Using "Object.assign(returnObject, another)" would lose
+                   * "A" as it would replace the entire PBXTargetDependency.
+                   *
+                   * Instead, we will merge each top-level property of the
+                   * objects, if it exists and is an object else add.
+                   */
+                  for (var key in another) {
+                      returnObject[key] = (
+                          returnObject[key] &&
+                          another[key] &&
+                          typeof returnObject[key] === 'object' &&
+                          typeof another[key] === 'object'
+                      ) ? Object.assign(returnObject[key], another[key]) : another[key];
+                  }
               }
               return returnObject;
           },

--- a/lib/parser/pbxproj.pegjs
+++ b/lib/parser/pbxproj.pegjs
@@ -17,18 +17,6 @@
     under the License.
 */
 
-{
-    function merge_obj(obj, secondObj) {
-        if (!obj)
-            return secondObj;
-
-        for(var i in secondObj)
-            obj[i] = merge_obj(obj[i], secondObj[i]);
-
-        return obj;
-    }
-}
-
 /*
  *  Project: point of entry from pbxproj file
  */
@@ -60,9 +48,47 @@ AssignmentList
   = _ list:((a:Assignment / d:DelimitedSection) _)+
     {
         var returnObject = list[0][0];
-        for(var i = 1; i < list.length; i++){
+
+        for (var i = 1; i < list.length; i++) {
             var another = list[i][0];
-            returnObject = merge_obj(returnObject, another);
+
+            /*
+             * Ensure previously parsed section entries are not lost
+             *
+             * Example:
+             *
+             * If "returnObject" contains:
+             *
+             *  {
+             *      PBXTargetDependency: {
+             *          'A': {},
+             *          'A_comment': 'PBXTargetDependency'
+             *      }
+             *  }
+             *
+             * And "another" contains:
+             *
+             *  {
+             *      PBXTargetDependency: {
+             *          'B': {},
+             *          'B_comment': 'PBXTargetDependency'
+             *      }
+             *  }
+             *
+             * Using "Object.assign(returnObject, another)" would lose
+             * "A" as it would replace the entire PBXTargetDependency.
+             *
+             * Instead, we will merge each top-level property of the
+             * objects, if it exists and is an object else add.
+             */
+            for (var key in another) {
+                returnObject[key] = (
+                    returnObject[key] &&
+                    another[key] &&
+                    typeof returnObject[key] === 'object' &&
+                    typeof another[key] === 'object'
+                ) ? Object.assign(returnObject[key], another[key]) : another[key];
+            }
         }
         return returnObject;
     }


### PR DESCRIPTION
It appears that the changes from #14 were not added to the source grammar file.
If the parser were ever rebuilt, those changes would have been reverted.

Additionally, when I added those changes to the grammar source file, the parser test for `section-split` failed.

Based on commit https://github.com/apache/cordova-node-xcode/commit/d3bf486ac2c137eb29e0eafc49a89b67ee6f0535, it appears that properties of multiple sections with the same name should be able to be merged together and that Xcode is able to handle this correctly. While this might not be common, some tools may produce a project with split sections.

The changes from #14 replaced the `merge_obj` logic with `Object.assign`, resulting in a shallow merge. As a result, previously parsed entries from an earlier section with the same name would have been overwritten.

The original commit's `merge_obj` method was a recursive deep-merge, triggered for every property, and may have resulted in the "Maximum call stack size exceeded" error that PR #14 was attempting to resolve.

To support split sections, I believe we should shallow-merge the top-level properties of each section rather than the entire object. Because this only merges one level deeper and is still not a recursive deep merge, I believe it could continue to avoid the "Maximum call stack size exceeded" error that PR #14 was addressing.