### PR TITLE
feat: add support for runOnlyForDeploymentPostprocessing

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1614,6 +1614,7 @@ function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
+    obj.runOnlyForDeploymentPostprocessing = options.runOnlyForDeploymentPostprocessing || 0;
 
     return obj;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1614,7 +1614,7 @@ function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
-    obj.runOnlyForDeploymentPostprocessing = options.runOnlyForDeploymentPostprocessing || 0;
+    obj.runOnlyForDeploymentPostprocessing = options.runOnlyForDeploymentPostprocessing === 1 ? 1 : 0;
 
     return obj;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1614,7 +1614,12 @@ function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
     obj.outputPaths = options.outputPaths || [];
     obj.shellPath = options.shellPath;
     obj.shellScript = '"' + options.shellScript.replace(/"/g, '\\"') + '"';
-    obj.runOnlyForDeploymentPostprocessing = options.runOnlyForDeploymentPostprocessing === 1 ? 1 : 0;
+
+    // By default, runOnlyForDeploymentPostprocessing is set to 0.
+    // Any truthy value, it will be set to 1, including any non-empty strings.
+    if (options.runOnlyForDeploymentPostprocessing) {
+        obj.runOnlyForDeploymentPostprocessing = 1;
+    }
 
     return obj;
 }

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -191,4 +191,10 @@ describe('addBuildPhase', () => {
         assert.equal(buildPhase.shellPath, '/bin/sh');
         assert.equal(buildPhase.shellScript, '"echo \\"hello world!\\""');
     });
+
+    it('should add runOnlyForDeploymentPostprocessing option to run scripts', () => {
+        const options = { shellPath: '/bin/sh', shellScript: 'echo "hello world!"', runOnlyForDeploymentPostprocessing: 1 };
+        const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+        assert.equal(buildPhase.runOnlyForDeploymentPostprocessing, 1);
+    });
 });


### PR DESCRIPTION
This PR cherry-picked, rebased, and resolved merging conflicts of PR #80. 
The forked repository of PR #80 has been since deleted.

This PR also will:

- Closes #80 
- Resolves #49

---

Additional Changes:

- Sets `runOnlyForDeploymentPostprocessing` to 1 with any truthy value, including non-empty strings.