### PR TITLE
feat: support for 'alwaysOutOfDate' PBX Shell Script property

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1621,8 +1621,10 @@ function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
         obj.runOnlyForDeploymentPostprocessing = 1;
     }
 
-    if (options.alwaysOutOfDate !== null) {
-        obj.alwaysOutOfDate = options.alwaysOutOfDate;
+    // By default, alwaysOutOfDate is not set and treated as false.
+    // Any truthy value, it will be set to 1, including any non-empty strings.
+    if (options.alwaysOutOfDate) {
+        obj.alwaysOutOfDate = 1;
     }
 
     return obj;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1621,6 +1621,10 @@ function pbxShellScriptBuildPhaseObj (obj, options, phaseName) {
         obj.runOnlyForDeploymentPostprocessing = 1;
     }
 
+    if (options.alwaysOutOfDate !== null) {
+        obj.alwaysOutOfDate = options.alwaysOutOfDate;
+    }
+
     return obj;
 }
 

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -208,7 +208,7 @@ describe('addBuildPhase', () => {
         const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
         assert.equal(buildPhase.shellPath, '/bin/sh');
         assert.equal(buildPhase.shellScript, '"test"');
-        assert.equal(buildPhase.alwaysOutOfDate, 1);
+        assert.strictEqual(buildPhase.alwaysOutOfDate, 1);
     });
 
     it('should add the PBXBuildPhase without alwaysOutOfDate property', () => {
@@ -217,6 +217,6 @@ describe('addBuildPhase', () => {
         const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
         assert.equal(buildPhase.shellPath, '/bin/sh');
         assert.equal(buildPhase.shellScript, '"test"');
-        assert.equal(buildPhase.alwaysOutOfDate, null);
+        assert.strictEqual(buildPhase.alwaysOutOfDate, undefined);
     });
 });

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -197,4 +197,26 @@ describe('addBuildPhase', () => {
         const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
         assert.equal(buildPhase.runOnlyForDeploymentPostprocessing, 1);
     });
+
+    it('should add the PBXBuildPhase with alwaysOutOfDate property', () => {
+        const options = {
+            shellPath: '/bin/sh',
+            shellScript: 'test',
+            alwaysOutOfDate: true
+        };
+
+        const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+        assert.equal(buildPhase.shellPath, '/bin/sh');
+        assert.equal(buildPhase.shellScript, '"test"');
+        assert.equal(buildPhase.alwaysOutOfDate, 1);
+    });
+
+    it('should add the PBXBuildPhase without alwaysOutOfDate property', () => {
+        const options = { shellPath: '/bin/sh', shellScript: 'test' };
+
+        const buildPhase = proj.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Run a script', proj.getFirstTarget().uuid, options).buildPhase;
+        assert.equal(buildPhase.shellPath, '/bin/sh');
+        assert.equal(buildPhase.shellScript, '"test"');
+        assert.equal(buildPhase.alwaysOutOfDate, null);
+    });
 });


### PR DESCRIPTION
This PR cherry-picks the changes from PR #143, rebases them, and resolves the merge conflicts.

Since PR #143 is over two years old, I wasn't sure whether @marco-saia-datadog was still active or would be willing to rebase it. At the same time, I didn't want to rebase their branch on their behalf (if possible), as they may still be using their repository for their own projects.

Because this PR is based on a cherry-pick, the original author will still receive recognition for the work they contributed.

See #143 for any additional context and discussion around this feature.

This PR also:

* Closes #143

---

**Additional changes:**

* Updates `alwaysOutOfDate` to evaluate to `1` for any truthy value, including non-empty strings.
* Updated tests to be strict equals.