### PR TITLE
chore(addBuildPhase): remove unused variable buildPhaseSection

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -921,7 +921,6 @@ PBXProject.prototype.addTargetDependency = function (target, dependencyTargets) 
  * @returns {AddBuildPhaseResults} object containing the build phase & uuid
  */
 PBXProject.prototype.addBuildPhase = function (filePathsArray, buildPhaseType, comment, target, optionsOrFolderType, subfolderPath) {
-    let buildPhaseSection;
     const fileReferenceSection = this.pbxFileReferenceSection();
     const buildFileSection = this.pbxBuildFileSection();
     const buildPhaseUuid = this.generateUuid();
@@ -1011,11 +1010,6 @@ PBXProject.prototype.addBuildPhase = function (filePathsArray, buildPhaseType, c
         this.addToPbxFileReferenceSection(file);
         this.addToPbxBuildFileSection(file);
         buildPhase.files.push(pbxBuildPhaseObj(file));
-    }
-
-    if (buildPhaseSection) {
-        buildPhaseSection[buildPhaseUuid] = buildPhase;
-        buildPhaseSection[commentKey] = comment;
     }
 
     return { uuid: buildPhaseUuid, buildPhase };


### PR DESCRIPTION
Remove unused variable `buildPhaseSection` in the `addBuildPhase`.

This variable appears to have been left behind during the refactoring in this commit, prior to this code base being contributed: https://github.com/alunny/node-xcode/commit/8b3c7f626bfada46b9b29d071e24745862540281

The current implementation still appears to preserve the original logic:

```js
if (!this.hash.project.objects[buildPhaseType]) {
    this.hash.project.objects[buildPhaseType] = {};
}

if (!this.hash.project.objects[buildPhaseType][buildPhaseUuid]) {
    this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
    this.hash.project.objects[buildPhaseType][commentKey] = comment;
}
```